### PR TITLE
BUG: fix 'No coverage report found.'

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+source = dtoolkit
 branch = True
 
 [report]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ jobs:
     needs: Linting
     name: ${{ matrix.os }}, ${{ matrix.env }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -28,6 +31,7 @@ jobs:
         env:
           - ci/envs/37.yaml
           - ci/envs/38.yaml
+
     steps:
       - uses: actions/checkout@v2
 
@@ -37,11 +41,9 @@ jobs:
           activate-conda: false
 
       - name: Install Env
-        shell: bash
         run: conda env create -f ${{ matrix.env }}
 
       - name: Check and Log Environment
-        shell: bash
         run: |
           source activate test
           python -V
@@ -49,10 +51,11 @@ jobs:
           conda list
 
       - name: Test with Pytest
-        shell: bash
         run: |
+          ls -la
           source activate test
           coverage run -m pytest
+          ls -la
 
       - name: Code Coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,10 +52,8 @@ jobs:
 
       - name: Test with Pytest
         run: |
-          ls -la
           source activate test
-          coverage run -m pytest
-          ls -la
+          pytest -v -r s -n auto --color=yes --cov --cov-append --cov-report term-missing --cov-report xml
 
       - name: Code Coverage
         uses: codecov/codecov-action@v1

--- a/ci/envs/37.yaml
+++ b/ci/envs/37.yaml
@@ -10,7 +10,6 @@ dependencies:
   - scikit-learn
   # testing
   - pytest
+  - pytest-cov
+  - pytest-xdist
   - codecov
-  - pip:
-      # testing
-      - coverage

--- a/ci/envs/38.yaml
+++ b/ci/envs/38.yaml
@@ -10,7 +10,6 @@ dependencies:
   - scikit-learn
   # testing
   - pytest
+  - pytest-cov
+  - pytest-xdist
   - codecov
-  - pip:
-      # testing
-      - coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 pytest
+pytest-cov
 codecov
-coverage


### PR DESCRIPTION
code coverage dependency changed, from coverage to pytest-cov
coverage supports unittests better, see https://github.com/codecov/example-python