### PR TITLE
EHN: api changed, `xx.col.columns` -> `xx.cols()`

### DIFF
--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -10,7 +10,7 @@ from ._typing import Pd
 @pd.api.extensions.register_dataframe_accessor("cols")
 @pd.api.extensions.register_series_accessor("cols")
 class PandasColumnAccessor:
-    def __new__(cls, pd_obj: Pd) -> Callable[..., str | pd.core.indexes.base.Index]:
+    def __new__(cls, pd_obj: Pd) -> Callable:
         def columns() -> str | pd.core.indexes.base.Index:
             if isinstance(pd_obj, pd.Series):
                 return pd_obj.name

--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
+from typing import Callable
+
 import pandas as pd
 
 from ._typing import Pd
 
 
-@pd.api.extensions.register_dataframe_accessor("col")
-@pd.api.extensions.register_series_accessor("col")
+@pd.api.extensions.register_dataframe_accessor("cols")
+@pd.api.extensions.register_series_accessor("cols")
 class PandasColumnAccessor:
-    def __init__(self, obj: Pd):
-        self._obj = obj
+    def __new__(cls, pd_obj: Pd) -> Callable[..., str | pd.core.indexes.base.Index]:
+        def columns() -> str | pd.core.indexes.base.Index:
+            if isinstance(pd_obj, pd.Series):
+                return pd_obj.name
+            else:
+                return pd_obj.columns
 
-    @property
-    def columns(self) -> str | pd.core.indexes.base.Index:
-        if isinstance(self._obj, pd.Series):
-            return self._obj.name
-        else:
-            return self._obj.columns
+        return columns

--- a/dtoolkit/tests/test_column.py
+++ b/dtoolkit/tests/test_column.py
@@ -1,14 +1,14 @@
 import pandas as pd
+import pytest
 from dtoolkit.accessor import PandasColumnAccessor  # noqa
 
-
-def test_series_column():
-    column = "item"
-    s = pd.Series(range(10), name=column)
-    assert s.col.columns == column
+s = pd.Series(range(10), name="item")
+d = pd.DataFrame({"a": range(10), "b": range(10)})
 
 
-def test_dataframe_column():
-    data = {"a": range(10), "b": range(10)}
-    d = pd.DataFrame(data)
-    assert list(d.col.columns) == list(data.keys())
+@pytest.mark.parametrize("df", [s, d])
+def test_column(df):
+    if isinstance(df, pd.Series):
+        assert df.cols() == df.name
+    else:
+        assert (df.cols() == df.columns).all()

--- a/dtoolkit/transformer.py
+++ b/dtoolkit/transformer.py
@@ -21,7 +21,7 @@ class DummifierTF(TransformerBase):
 
     @doc(pd.get_dummies)
     def transform(self, X: Pd, **params) -> pd.DataFrame:
-        columns = X.col.columns
+        columns = X.cols()
 
         if self.cols:
             X = X[self.cols]


### PR DESCRIPTION
hook in method not object