### PR TITLE
EHN, CLN: match test script to source and general generalize `ColumnAccessor`

### DIFF
--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -9,7 +9,7 @@ from ._typing import Pd
 
 @pd.api.extensions.register_dataframe_accessor("cols")
 @pd.api.extensions.register_series_accessor("cols")
-class PandasColumnAccessor:
+class ColumnAccessor:
     def __new__(cls, pd_obj: Pd) -> Callable:
         def columns() -> str | pd.core.indexes.base.Index:
             if isinstance(pd_obj, pd.Series):

--- a/dtoolkit/tests/test_accessor.py
+++ b/dtoolkit/tests/test_accessor.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from dtoolkit.accessor import PandasColumnAccessor  # noqa
+from dtoolkit.accessor import ColumnAccessor  # noqa
 
 s = pd.Series(range(10), name="item")
 d = pd.DataFrame({"a": range(10), "b": range(10)})

--- a/dtoolkit/tests/test_buffer.py
+++ b/dtoolkit/tests/test_buffer.py
@@ -6,6 +6,7 @@ import pandas._testing as tm
 import pytest
 from pyproj import CRS
 from shapely import wkt
+from shapely.geometry.base import BaseGeometry
 
 my_wkts = ["Point(120 50)", "Point(150 -30)", "Point(100 1)"]
 my_points = [wkt.loads(i) for i in my_wkts]
@@ -15,7 +16,8 @@ distances = np.asarray(range(1, 1000, 499))
 @pytest.mark.parametrize("crs", [None, "epsg:4326"])
 @pytest.mark.parametrize("epsg", [None, 4326])
 def test_to_crs_work(crs, epsg):
-    buffer.string_or_int_to_crs(crs, epsg)
+    c = buffer.string_or_int_to_crs(crs, epsg)
+    assert isinstance(c, CRS)
 
 
 def test_to_crs_missing():
@@ -36,7 +38,8 @@ class TestDealingOneGeometry:
     @pytest.mark.parametrize("geom", my_points)
     @pytest.mark.parametrize("distance", distances)
     def test_work(self, geom, distance):
-        buffer._geographic_buffer(geom, distance, self.crs)
+        b = buffer._geographic_buffer(geom, distance, self.crs)
+        assert isinstance(b, BaseGeometry)
 
     def test_geometry_is_none(self):
         res = buffer._geographic_buffer(None, self.distance, self.crs)
@@ -61,7 +64,8 @@ class TestDealingMultipleGeometry:
         "distance", [1000, list(distances), distances, pd.Series(distances)]
     )
     def test_distance_work(self, distance):
-        buffer.geographic_buffer(self.s, distance)
+        b = buffer.geographic_buffer(self.s, distance)
+        assert isinstance(b, gpd.GeoSeries)
 
     def test_distance_is_pd_series(self):
         df_distance = pd.Series(range(1, 1000, 499))

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -1,8 +1,17 @@
 import pandas as pd
 import pytest
 from dtoolkit._typing import PandasTypeList
-from dtoolkit.transformer import SelectorTF
+from dtoolkit.transformer import SelectorTF, TransformerBase
 from sklearn.datasets import load_iris
+
+# test TransformerBase
+
+def test_fit_work():
+    tf = TransformerBase()
+    assert tf is tf.fit()
+
+
+# test SelectorTF
 
 iris = load_iris()
 feature_names = iris.feature_names

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -6,6 +6,7 @@ from sklearn.datasets import load_iris
 
 # test TransformerBase
 
+
 def test_fit_work():
     tf = TransformerBase()
     assert tf is tf.fit()

--- a/dtoolkit/tests/test_transformerbase.py
+++ b/dtoolkit/tests/test_transformerbase.py
@@ -1,6 +1,0 @@
-from dtoolkit.transformer import TransformerBase
-
-
-def test_fit_work():
-    tf = TransformerBase()
-    assert tf is tf.fit()


### PR DESCRIPTION
- EHN: reanme `PandasColumnAccessor` -> `ColumnAccessor`, this function both work well for `pandas` and `geopandas`
- CLN: test script filename match to source