### PR TITLE
EHN: add port `numpy.ravel` to transformer

### DIFF
--- a/dtoolkit/_checking.py
+++ b/dtoolkit/_checking.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from shapely.geometry.base import BaseGeometry
 
-from ._typing import NumericType, NumericTypeList, GeoPandasList, GPd
+from ._typing import GeoPandasList, GPd, NumericType, NumericTypeList
 
 
 def istype(var: object, types: type | List[type] | Tuple[type]) -> bool:

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 from dtoolkit._typing import PandasTypeList
-from dtoolkit.transformer import SelectorTF, TransformerBase
+from dtoolkit.transformer import RavelTF, SelectorTF, TransformerBase
 from sklearn.datasets import load_iris
 
 
@@ -13,6 +13,7 @@ def test_transformbase():
 iris = load_iris()
 feature_names = iris.feature_names
 df = pd.DataFrame(iris.data, columns=feature_names)
+s = df[feature_names[0]]
 
 
 class TestSelectorTF:
@@ -38,3 +39,9 @@ class TestSelectorTF:
     def test_data_is_not_dataframe(self):
         with pytest.raises(TypeError):
             SelectorTF().transform(iris.data)
+
+
+@pytest.mark.parametrize("data", [iris.data, df, s, s.tolist()])
+def test_raveltf(data):
+    transformed_data = RavelTF.transform(data)
+    assert transformed_data.ndim == 1

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -4,19 +4,10 @@ from dtoolkit._typing import PandasTypeList
 from dtoolkit.transformer import SelectorTF, TransformerBase
 from sklearn.datasets import load_iris
 
-# -----------------------------------------------------------------------------
-# TransformerBase test
-# -----------------------------------------------------------------------------
-
 
 def test_transformbase():
     tf = TransformerBase()
     assert tf is tf.fit()
-
-
-# -----------------------------------------------------------------------------
-# SelectorTF test
-# -----------------------------------------------------------------------------
 
 
 iris = load_iris()
@@ -24,28 +15,26 @@ feature_names = iris.feature_names
 df = pd.DataFrame(iris.data, columns=feature_names)
 
 
-@pytest.mark.parametrize("cols", [feature_names[0], feature_names[1:]])
-def test_transform(cols):
-    tf = SelectorTF(cols)
-    assert all(tf.transform(df) == df[cols])
+class TestSelectorTF:
+    @pytest.mark.parametrize("cols", [feature_names[0], feature_names[1:]])
+    def test_transform(self, cols):
+        tf = SelectorTF(cols)
+        assert all(tf.transform(df) == df[cols])
 
+    @pytest.mark.parametrize("cols", [feature_names[0], feature_names[1:]])
+    def test_fit_transform(self, cols):
+        tf = SelectorTF(cols)
+        assert all(tf.fit_transform(df) == df[cols])
 
-@pytest.mark.parametrize("cols", [feature_names[0], feature_names[1:]])
-def test_fit_transform(cols):
-    tf = SelectorTF(cols)
-    assert all(tf.fit_transform(df) == df[cols])
+    @pytest.mark.parametrize("X", [iris, df])
+    @pytest.mark.parametrize("cols", [None, feature_names])
+    def test_inverse_transform(self, X, cols):
+        tf = SelectorTF(cols)
+        if isinstance(X, tuple(PandasTypeList)):
+            assert all(X == tf.inverse_transform(X))
+        else:
+            assert X == tf.inverse_transform(X)
 
-
-@pytest.mark.parametrize("X", [iris, df])
-@pytest.mark.parametrize("cols", [None, feature_names])
-def test_inverse_transform(X, cols):
-    tf = SelectorTF(cols)
-    if isinstance(X, tuple(PandasTypeList)):
-        assert all(X == tf.inverse_transform(X))
-    else:
-        assert X == tf.inverse_transform(X)
-
-
-def test_data_is_not_dataframe():
-    with pytest.raises(TypeError):
-        SelectorTF().transform(iris.data)
+    def test_data_is_not_dataframe(self):
+        with pytest.raises(TypeError):
+            SelectorTF().transform(iris.data)

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -9,7 +9,7 @@ from sklearn.datasets import load_iris
 # -----------------------------------------------------------------------------
 
 
-def test_fit_work():
+def test_transformbase():
     tf = TransformerBase()
     assert tf is tf.fit()
 

--- a/dtoolkit/transformer.py
+++ b/dtoolkit/transformer.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import List
 
+import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin
+from sklearn.preprocessing import FunctionTransformer
 
-from ._typing import Pd
 from ._checking import bad_condition_raise_error
+from ._typing import Pd
 
 
 class TransformerBase(TransformerMixin):
@@ -32,3 +34,6 @@ class SelectorTF(TransformerBase):
 
     def inverse_transform(self, X: pd.DataFrame, *_) -> Pd:
         return X
+
+
+RavelTF = FunctionTransformer(np.ravel)


### PR DESCRIPTION
- CLN: sort imports
- CLN, TST: use class name to replace annotation
- CLN, TST: change test function name to match the source
- EHN: add port `numpy.ravel` to transformer
- TST: add `RavelTF` test example