### PR TITLE
EHN: add drop inf accessor for pandas

### DIFF
--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -11,10 +11,10 @@ from ._typing import Pd
 @pd.api.extensions.register_series_accessor("cols")
 class ColumnAccessor:
     def __new__(cls, pd_obj: Pd) -> Callable:
-        def columns() -> str | pd.core.indexes.base.Index:
+        def cols() -> str | pd.core.indexes.base.Index:
             if isinstance(pd_obj, pd.Series):
                 return pd_obj.name
             else:
                 return pd_obj.columns
 
-        return columns
+        return cols

--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+import numpy as np
 import pandas as pd
 
 from ._typing import Pd
@@ -18,3 +19,12 @@ class ColumnAccessor:
                 return pd_obj.columns
 
         return cols
+
+
+@pd.api.extensions.register_series_accessor("dropinf")
+class DropInfAccessor:
+    def __new__(cls, pd_obj: pd.Series) -> Callable:
+        def dropinf() -> pd.Series:
+            return pd_obj[~np.isinf(pd_obj)]
+
+        return dropinf

--- a/dtoolkit/tests/test_accessor.py
+++ b/dtoolkit/tests/test_accessor.py
@@ -1,9 +1,12 @@
+import numpy as np
 import pandas as pd
 import pytest
 from dtoolkit.accessor import ColumnAccessor  # noqa
+from dtoolkit.accessor import DropInfAccessor  # noqa
 
 s = pd.Series(range(10), name="item")
 d = pd.DataFrame({"a": range(10), "b": range(10)})
+s_inf = pd.Series([np.inf, -np.inf])
 
 
 @pytest.mark.parametrize("df", [s, d])
@@ -12,3 +15,8 @@ def test_columnaccessor(df):
         assert df.cols() == df.name
     else:
         assert (df.cols() == df.columns).all()
+
+
+@pytest.mark.parametrize("df", [s, s.append(s_inf)])
+def test_dropinfaccessor(df):
+    assert (df.dropinf() == s).all()

--- a/dtoolkit/tests/test_accessor.py
+++ b/dtoolkit/tests/test_accessor.py
@@ -7,7 +7,7 @@ d = pd.DataFrame({"a": range(10), "b": range(10)})
 
 
 @pytest.mark.parametrize("df", [s, d])
-def test_column(df):
+def test_columnaccessor(df):
     if isinstance(df, pd.Series):
         assert df.cols() == df.name
     else:


### PR DESCRIPTION
- CLN, TST: rename function name to match source
- EHN: add drop inf accessor for pandas
- TST: add test example for `DropInfAccessor`