### PR TITLE
EHN, TYP: clarify `cols` type and let return type is `DataFrame`

### DIFF
--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -17,6 +17,11 @@ s = df[feature_names[0]]
 
 
 class TestSelectorTF:
+    @pytest.mark.parametrize("cols", [feature_names, feature_names[0]])
+    def test_init(self, cols):
+        tf = SelectorTF(cols)
+        assert isinstance(tf.cols, list)
+
     @pytest.mark.parametrize("cols", [[feature_names[0]], feature_names[1:]])
     def test_fit_transform(self, cols):
         tf = SelectorTF(cols)

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -17,12 +17,7 @@ s = df[feature_names[0]]
 
 
 class TestSelectorTF:
-    @pytest.mark.parametrize("cols", [feature_names[0], feature_names[1:]])
-    def test_transform(self, cols):
-        tf = SelectorTF(cols)
-        assert all(tf.transform(df) == df[cols])
-
-    @pytest.mark.parametrize("cols", [feature_names[0], feature_names[1:]])
+    @pytest.mark.parametrize("cols", [[feature_names[0]], feature_names[1:]])
     def test_fit_transform(self, cols):
         tf = SelectorTF(cols)
         assert all(tf.fit_transform(df) == df[cols])

--- a/dtoolkit/transformer.py
+++ b/dtoolkit/transformer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -8,7 +8,6 @@ from sklearn.base import TransformerMixin
 from sklearn.preprocessing import FunctionTransformer
 
 from ._checking import bad_condition_raise_error
-from ._typing import Pd
 
 
 class TransformerBase(TransformerMixin):
@@ -17,10 +16,13 @@ class TransformerBase(TransformerMixin):
 
 
 class SelectorTF(TransformerBase):
-    def __init__(self, cols: List[str] = None):
+    def __init__(self, cols: str | List[str] | Tuple[str] = None):
+        if isinstance(cols, str):
+            cols = [cols]
+
         self.cols = cols
 
-    def transform(self, X: pd.DataFrame) -> Pd:
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         bad_condition_raise_error(
             not isinstance(X, pd.DataFrame),
             TypeError,
@@ -29,10 +31,10 @@ class SelectorTF(TransformerBase):
 
         return X[self.cols] if self.cols else X
 
-    def fit_transform(self, X: pd.DataFrame, *_) -> Pd:
+    def fit_transform(self, X: pd.DataFrame, *_) -> pd.DataFrame:
         return self.transform(X)
 
-    def inverse_transform(self, X: pd.DataFrame, *_) -> Pd:
+    def inverse_transform(self, X: pd.DataFrame, *_) -> pd.DataFrame:
         return X
 
 


### PR DESCRIPTION
- EHN, TYP: clarify `cols` type and let return type is `DataFrame`
- CLN, TST: drop duplicated tests
- TST: test `cols` input type