### PR TITLE
TST: fix overlaping with builtins: ('sum')

### DIFF
--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -146,8 +146,8 @@ def test_raveltf(data):
 
 def gen_x_pipeline():
     return make_pipeline(
-        EvalTF(f"sum = `{'` + `'.join(feature_names)}`"),
-        QueryTF("sum > 10"),
+        EvalTF(f"`sum_feature` = `{'` + `'.join(feature_names)}`"),
+        QueryTF("`sum_feature` > 10"),
         GetTF(feature_names),
         DropTF(columns=feature_names[:2]),
         MinMaxScaler(),
@@ -177,7 +177,8 @@ class TestPipeline:
 
 
 @pytest.mark.parametrize(
-    "name,pipe", [("x", gen_x_pipeline()), ("y", gen_y_pipeline())]
+    "name,pipe",
+    [("x", gen_x_pipeline()), ("y", gen_y_pipeline())],
 )
 def test_save_to_file(name, pipe):
     pipe.fit(df)

--- a/dtoolkit/tests/test_transformer.py
+++ b/dtoolkit/tests/test_transformer.py
@@ -178,7 +178,10 @@ class TestPipeline:
 
 @pytest.mark.parametrize(
     "name,pipe",
-    [("x", gen_x_pipeline()), ("y", gen_y_pipeline())],
+    [
+        ("x", gen_x_pipeline()),
+        ("y", gen_y_pipeline()),
+    ],
 )
 def test_save_to_file(name, pipe):
     pipe.fit(df)


### PR DESCRIPTION
https://github.com/Zeroto521/my-data-toolkit/runs/3119664954?check_suite_focus=true#step:5:288

```python
[gw0] linux -- Python 3.8.10 /usr/share/miniconda/envs/test/bin/python

self = <dtoolkit.tests.test_transformer.TestPipeline object at 0x7faae9790a00>

    def test_x_pipeline_work(self):
        pipe = gen_x_pipeline()
>       transformed_data = pipe.fit_transform(df)

dtoolkit/tests/test_transformer.py:164: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/sklearn/pipeline.py:378: in fit_transform
    Xt = self._fit(X, y, **fit_params_steps)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/sklearn/pipeline.py:303: in _fit
    X, fitted_transformer = fit_transform_one_cached(
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/joblib/memory.py:352: in __call__
    return self.func(*args, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/sklearn/pipeline.py:754: in _fit_transform_one
    res = transformer.fit_transform(X, y, **fit_params)
dtoolkit/transformer.py:34: in fit_transform
    return self.fit().transform(X)
dtoolkit/transformer.py:31: in transform
    return self.operate(X, *self.args, **self.kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/frame.py:4055: in query
    res = self.eval(expr, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/frame.py:4186: in eval
    return _eval(expr, inplace=inplace, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/eval.py:353: in eval
    ret = eng_inst.evaluate()
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/engines.py:80: in evaluate
    res = self._evaluate()
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/engines.py:120: in _evaluate
    _check_ne_builtin_clash(self.expr)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

expr = (sum) > (10)

    def _check_ne_builtin_clash(expr: Expr) -> None:
        """
        Attempt to prevent foot-shooting in a helpful way.
    
        Parameters
        ----------
        expr : Expr
            Terms can contain
        """
        names = expr.names
        overlap = names & _ne_builtins
    
        if overlap:
            s = ", ".join(repr(x) for x in overlap)
>           raise NumExprClobberingError(
                f'Variables in expression "{expr}" overlap with builtins: ({s})'
            )
E           pandas.core.computation.engines.NumExprClobberingError: Variables in expression "(sum) > (10)" overlap with builtins: ('sum')

/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/engines.py:41: NumExprClobberingError
__________________________ test_save_to_file[x-pipe0] __________________________
[gw1] linux -- Python 3.8.10 /usr/share/miniconda/envs/test/bin/python

name = 'x'
pipe = Pipeline(steps=[('evaltf',
                 <dtoolkit.transformer.EvalTF object at 0x7fe9e1955e80>),
                (...            <dtoolkit.transformer.DropTF object at 0x7fe9e19604f0>),
                ('minmaxscaler', MinMaxScaler())])

    @pytest.mark.parametrize(
        "name,pipe", [("x", gen_x_pipeline()), ("y", gen_y_pipeline())]
    )
    def test_save_to_file(name, pipe):
>       pipe.fit(df)

dtoolkit/tests/test_transformer.py:183: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/sklearn/pipeline.py:341: in fit
    Xt = self._fit(X, y, **fit_params_steps)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/sklearn/pipeline.py:303: in _fit
    X, fitted_transformer = fit_transform_one_cached(
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/joblib/memory.py:352: in __call__
    return self.func(*args, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/sklearn/pipeline.py:754: in _fit_transform_one
    res = transformer.fit_transform(X, y, **fit_params)
dtoolkit/transformer.py:34: in fit_transform
    return self.fit().transform(X)
dtoolkit/transformer.py:31: in transform
    return self.operate(X, *self.args, **self.kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/frame.py:4055: in query
    res = self.eval(expr, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/frame.py:4186: in eval
    return _eval(expr, inplace=inplace, **kwargs)
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/eval.py:353: in eval
    ret = eng_inst.evaluate()
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/engines.py:80: in evaluate
    res = self._evaluate()
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/pandas/core/computation/engines.py:120: in _evaluate
    _check_ne_builtin_clash(self.expr)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

expr = (sum) > (10)

    def _check_ne_builtin_clash(expr: Expr) -> None:
        """
        Attempt to prevent foot-shooting in a helpful way.
    
        Parameters
        ----------
        expr : Expr
            Terms can contain
        """
        names = expr.names
        overlap = names & _ne_builtins
    
        if overlap:
            s = ", ".join(repr(x) for x in overlap)
>           raise NumExprClobberingError(
                f'Variables in expression "{expr}" overlap with builtins: ({s})'
            )
E           pandas.core.computation.engines.NumExprClobberingError: Variables in expression "(sum) > (10)" overlap with builtins: ('sum')
```