### PR TITLE
EHN: create `df.filterin` function

### DIFF
--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -26,3 +26,24 @@ def DropInfAccessor(s: pd.Series) -> Callable[..., pd.Series]:
         return s[~np.isinf(s)]
 
     return dropinf
+
+
+@pd.api.extensions.register_dataframe_accessor("filterin")
+def FilterInAccessor(
+    df: pd.DataFrame,
+) -> Callable[[dict[str, list[str]], bool], pd.DataFrame | None]:
+    def filterin(
+        cond: dict[str, list[str]],
+        inplace: bool = False,
+    ) -> pd.DataFrame | None:
+        mask_all = df.isin(cond)
+        mask_selected = mask_all[cond.keys()]
+        result = df[mask_selected.all(axis=1)]
+
+        if inplace:
+            df._update_inplace(result)
+            return None
+
+        return result
+
+    return filterin

--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -21,8 +21,8 @@ def ColumnAccessor(pd_obj: Pd) -> Callable[..., Pd]:
 
 
 @pd.api.extensions.register_series_accessor("dropinf")
-def DropInfAccessor(pd_obj: pd.Series) -> Callable[..., pd.Series]:
+def DropInfAccessor(s: pd.Series) -> Callable[..., pd.Series]:
     def dropinf() -> pd.Series:
-        return pd_obj[~np.isinf(pd_obj)]
+        return s[~np.isinf(s)]
 
     return dropinf

--- a/dtoolkit/accessor.py
+++ b/dtoolkit/accessor.py
@@ -10,7 +10,7 @@ from ._typing import Pd
 
 @pd.api.extensions.register_dataframe_accessor("cols")
 @pd.api.extensions.register_series_accessor("cols")
-def ColumnAccessor(pd_obj: Pd) -> Callable:
+def ColumnAccessor(pd_obj: Pd) -> Callable[..., Pd]:
     def cols() -> str | pd.core.indexes.base.Index:
         if isinstance(pd_obj, pd.Series):
             return pd_obj.name
@@ -21,7 +21,7 @@ def ColumnAccessor(pd_obj: Pd) -> Callable:
 
 
 @pd.api.extensions.register_series_accessor("dropinf")
-def DropInfAccessor(pd_obj: pd.Series) -> Callable:
+def DropInfAccessor(pd_obj: pd.Series) -> Callable[..., pd.Series]:
     def dropinf() -> pd.Series:
         return pd_obj[~np.isinf(pd_obj)]
 

--- a/dtoolkit/tests/test_accessor.py
+++ b/dtoolkit/tests/test_accessor.py
@@ -4,12 +4,20 @@ import pytest
 
 from dtoolkit.accessor import ColumnAccessor  # noqa
 from dtoolkit.accessor import DropInfAccessor  # noqa
+from dtoolkit.accessor import FilterInAccessor  # noqa
 
 
-s = pd.Series(range(10), name="item")
+data_size = 10
+s = pd.Series(range(data_size), name="item")
 s = s.astype(float)
 
-d = pd.DataFrame({"a": range(10), "b": range(10)})
+label_size = 3
+d = pd.DataFrame(
+    {
+        "a": np.random.randint(label_size, size=data_size),
+        "b": np.random.randint(label_size, size=data_size),
+    },
+)
 s_inf = pd.Series([np.inf, -np.inf])
 
 
@@ -24,3 +32,23 @@ def test_columnaccessor(df):
 @pytest.mark.parametrize("df", [s, s.append(s_inf)])
 def test_dropinfaccessor(df):
     assert s.equals(df.dropinf())
+
+
+class TestFilterInAccessor:
+    def setup_method(self):
+        self.d = d.copy(True)
+        self.condition = {"a": [0, 1], "b": [2]}
+
+    def test_work(self):
+        res = self.d.filterin(self.condition)
+
+        assert res["a"].isin([0, 1]).any()  # 0 and 1 in a
+        assert (~res["a"].isin([2])).all()  # 2 not in a
+        assert res["b"].isin([2]).any()  # 2 in a
+        assert (~res["b"].isin([0, 1])).all()  # 0 and not in a
+
+    def test_inplace_is_true(self):
+        res = self.d.filterin(self.condition, inplace=True)
+
+        assert res is None
+        assert self.d.equals(d) is False


### PR DESCRIPTION
- TYP: specific return callable type
- CLN: rename input argument
- EHN: create `df.filterin` function
- TST: test filterin accessor