### PR TITLE
MAINT: specific `filterin` each parameter function

### DIFF
--- a/dtoolkit/accessor/dataframe.py
+++ b/dtoolkit/accessor/dataframe.py
@@ -191,10 +191,12 @@ class FilterInAccessor(DataFrameAccessor):
     condition : iterable, Series, DataFrame or dict
         The result will only be true at a location if all the labels match.
 
-        * If ``condition`` is a :obj:`dict`, the keys must be the row/column names
-          , which must match. And ``how`` only works on these gave keys.
-            - ``axis`` is 0 or 'index', keys would be recognize as column names.
-            - ``axis`` is 1 or 'columns', keys would be recognize as index names.
+        * If ``condition`` is a :obj:`dict`, the keys must be the row/column
+          names, which must match. And ``how`` only works on these gave keys.
+            - ``axis`` is 0 or 'index', keys would be recognize as column
+              names.
+            - ``axis`` is 1 or 'columns', keys would be recognize as index
+              names.
 
         * If ``condition`` is a :obj:`~pandas.Series`, that's the index.
         * If ``condition`` is a :obj:`~pandas.DataFrame`, then both the index

--- a/dtoolkit/accessor/dataframe.py
+++ b/dtoolkit/accessor/dataframe.py
@@ -36,11 +36,13 @@ class DataFrameAccessor(Accessor):
 
         if isinstance(values, dict) and axis == 1:
             values = defaultdict(list, values)
-            res = (
-                self.pd_obj.iloc[[i], :].isin(values[ind])
-                for i, ind in enumerate(self.pd_obj.index)
+            return pd.concat(
+                (
+                    self.pd_obj.iloc[[i], :].isin(values[ind])
+                    for i, ind in enumerate(self.pd_obj.index)
+                ),
+                axis=0,
             )
-            return pd.concat(res, axis=0)
 
         return self.pd_obj.isin(values)
 

--- a/dtoolkit/accessor/dataframe.py
+++ b/dtoolkit/accessor/dataframe.py
@@ -36,10 +36,10 @@ class DataFrameAccessor(Accessor):
 
         if isinstance(values, dict) and axis == 1:
             values = defaultdict(list, values)
-            res = [
+            res = (
                 self.pd_obj.iloc[[i], :].isin(values[ind])
                 for i, ind in enumerate(self.pd_obj.index)
-            ]
+            )
             return pd.concat(res, axis=0)
 
         return self.pd_obj.isin(values)

--- a/dtoolkit/accessor/tests/test_dataframe.py
+++ b/dtoolkit/accessor/tests/test_dataframe.py
@@ -146,6 +146,27 @@ class TestFilterInAccessor:
         assert res is None
         assert self.d.equals(d) is False
 
+    def test_issue_145(self):
+        # test my-data-toolkit#145
+        df = pd.DataFrame(
+            {
+                "legs": [2, 4, 2],
+                "wings": [2, 0, 0],
+            },
+            index=["falcon", "dog", "cat"],
+        )
+        res = df.filterin({"legs": [2]})
+
+        expected = pd.DataFrame(
+            {
+                "legs": [2, 2],
+                "wings": [2, 0],
+            },
+            index=["falcon", "cat"],
+        )
+
+        assert res.equals(expected)
+
 
 class TestRepeatAccessor:
     def setup_method(self):


### PR DESCRIPTION
The core problem is `DataFrame.isin` can only recognize `values`' key as column names.
To fix #145.