### PR TITLE
EHN:  `update_invargs` supports keeping the old args

### DIFF
--- a/dtoolkit/transformer/base.py
+++ b/dtoolkit/transformer/base.py
@@ -76,7 +76,7 @@ class MethodTF(Transformer):
     def update_invargs(self, *args, **kwargs):
         """Inverse transform method arguement entry."""
 
-        self.inverse_args = args
+        self.inverse_args = args or self.inverse_args
         self.inverse_kwargs.update(kwargs)
 
         return self

--- a/dtoolkit/transformer/base.py
+++ b/dtoolkit/transformer/base.py
@@ -77,7 +77,7 @@ class MethodTF(Transformer):
         """Inverse transform method arguement entry."""
 
         self.inverse_args = args
-        self.inverse_kwargs = kwargs
+        self.inverse_kwargs.update(kwargs)
 
         return self
 


### PR DESCRIPTION
Now `update_invargs` supports keeping the old args.

use twice `update_invargs`, the newer args wouldn't totally cover the older args.