### PR TITLE
CI: let conda only use conda-forge channel

### DIFF
--- a/ci/envs/37-minimal.yaml
+++ b/ci/envs/37-minimal.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.7

--- a/ci/envs/37.yaml
+++ b/ci/envs/37.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.7

--- a/ci/envs/38-dev.yaml
+++ b/ci/envs/38-dev.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.8

--- a/ci/envs/38-minimal.yaml
+++ b/ci/envs/38-minimal.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.8

--- a/ci/envs/38.yaml
+++ b/ci/envs/38.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.8

--- a/ci/envs/39-minimal.yaml
+++ b/ci/envs/39-minimal.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.8

--- a/ci/envs/39.yaml
+++ b/ci/envs/39.yaml
@@ -1,6 +1,5 @@
 name: test
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - python=3.9


### PR DESCRIPTION
Conda default channel hasn't updated to geopandas v0.10.0
Or it could say geopandas always release at conda-forge and pypi first.