### PR TITLE
DOC: change api url

### DIFF
--- a/doc/source/reference/accessor.rst
+++ b/doc/source/reference/accessor.rst
@@ -6,7 +6,7 @@ Series Accessor
 ---------------
 .. currentmodule:: dtoolkit.accessor.series
 .. autosummary::
-    :toctree: api/accessor/
+    :toctree: api/
 
     cols
     dropinf
@@ -18,7 +18,7 @@ DataFrame Accessor
 ------------------
 .. currentmodule:: dtoolkit.accessor.dataframe
 .. autosummary::
-    :toctree: api/accessor/
+    :toctree: api/
 
     cols
     dropinf
@@ -31,7 +31,7 @@ Register
 --------
 .. currentmodule:: dtoolkit.accessor.register
 .. autosummary::
-    :toctree: api/accessor/
+    :toctree: api/
 
     register_series_method
     register_dataframe_method

--- a/doc/source/reference/geography.rst
+++ b/doc/source/reference/geography.rst
@@ -8,6 +8,6 @@ Geography
 Geographic Buffer Generation
 ----------------------------
 .. autosummary::
-    :toctree: api/geography/
+    :toctree: api/
 
     geographic_buffer

--- a/doc/source/reference/transformer.rst
+++ b/doc/source/reference/transformer.rst
@@ -11,7 +11,7 @@ Base Transformer
 Base transformer class for all transformers.
 
 .. autosummary::
-    :toctree: api/transformer/base
+    :toctree: api/
 
     Transformer
     MethodTF
@@ -23,7 +23,7 @@ Base transformer class for all transformers.
 Sklearn Transformer
 -------------------
 .. autosummary::
-    :toctree: api/transformer/sklearn
+    :toctree: api/
 
     OneHotEncoder
     MinMaxScaler
@@ -38,7 +38,7 @@ The parameters of transformer (``args``, ``kwargs``) are the same to
 corresponding to relative :class:`pandas.DataFrame`'s method.
 
 .. autosummary::
-    :toctree: api/transformer/pandas
+    :toctree: api/
 
     AssignTF
     AppendTF
@@ -59,6 +59,6 @@ The parameters of transformer (``args``, ``kwargs``) are the same to
 corresponding to relative :class:`numpy.ndarray`'s method.
 
 .. autosummary::
-    :toctree: api/transformer/numpy
+    :toctree: api/
 
     RavelTF

--- a/doc/source/reference/utility.rst
+++ b/doc/source/reference/utility.rst
@@ -4,7 +4,7 @@ Utility
 
 
 .. autosummary::
-    :toctree: api/util/
+    :toctree: api/
 
     multi_if_else
     snake_to_camel


### PR DESCRIPTION
no more parent, the html's name already has

`reference/api/geography/dtoolkit.geography.geographic_buffer.html` -> `reference/api/dtoolkit.geography.geographic_buffer.html`