### PR TITLE
CI: use artifact to save sdist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
 
-      - name: Build a Binary Wheel and a Source Tarball
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-          make dist
+      - name: Install Dependencies
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Build sdist
+        run: make dist
 
       - name: Get Source Tarball Name
         id: tar
@@ -33,6 +33,11 @@ jobs:
           export file=$(ls dist/ | grep ${type})
           echo "::set-output name=file::${file}"
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: release
+          path: dist/
+
     outputs:
       var: ${{ steps.tar.outputs.file }}
       whl: ${{ steps.whl.outputs.file }}
@@ -43,6 +48,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: release
+          path: dist/
+
+      - name: List dist/ Folder
+        run: ls dist/ -l
 
       - name: Upload Release Asset to GitHub
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
To fix CI can't upload sdist, see https://github.com/Zeroto521/my-data-toolkit/runs/3958875284?check_suite_focus=true#step:3:7