### PR TITLE
DOC: fix doc env missing ipython

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - pydata-sphinx-theme
   - myst-parser
   - numpydoc
+  - ipython
   - pip
   - pip:
       - sphinx-toggleprompt


### PR DESCRIPTION
```
ModuleNotFoundError: No module named 'IPython'
```

https://readthedocs.org/projects/my-data-toolkit/builds/15123598/

closed #259