### PR TITLE
BLD: use pep440-old style

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -50,5 +50,4 @@ jobs:
       - name: Import dtoolkit
         run: |
           cd ..
-          conda list
-          python -c "import dtoolkit; print(dtoolkit.__version__);"
+          make info

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY : help clean lint test doctest dist info html
 
-pkg = dtoolkit
-
 help:
 	@echo "'clean' - remove all cached files"
 	@echo "'clean-build' - remove build artifacts"
@@ -12,7 +10,7 @@ help:
 	@echo "'lint' - lint source codes"
 	@echo "'dist' - build package"
 	@echo "'test' - run tests and check coverage"
-	@echo "'info' - show conda environment and $(pkg) information"
+	@echo "'info' - show conda environment and dtoolkit information"
 	@echo "'html' - build html documentation"
 
 clean-build:
@@ -44,10 +42,10 @@ lint:
 	pre-commit run -a -v
 
 test:
-	pytest -v -r a -n auto --color=yes --cov=$(pkg) --cov-append --cov-report term-missing --cov-report xml $(pkg)
+	pytest -v -r a -n auto --color=yes --cov=dtoolkit --cov-append --cov-report term-missing --cov-report xml dtoolkit
 
 doctest:
-	pytest -v -r a -n auto --color=yes --cov=$(pkg) --cov-append --cov-report xml --doctest-only $(pkg)
+	pytest -v -r a -n auto --color=yes --cov=dtoolkit --cov-append --cov-report xml --doctest-only dtoolkit
 
 dist:
 	python setup.py sdist bdist_wheel
@@ -55,7 +53,7 @@ dist:
 
 info:
 	python -V
-	python -c "import $(pkg); print($(pkg).__version__)"
+	python -c "import pprint; from dtoolkit._version import get_versions; pprint.pprint(get_versions());"
 	conda info
 	conda list
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ zip_safe = False
 
 [versioneer]
 VCS = git
-style = pep440
+style = pep440-old
 versionfile_source = dtoolkit/_version.py
 versionfile_build = dtoolkit/_version.py
 tag_prefix = v


### PR DESCRIPTION
1. fix "'0.0.4+65.g853b264' is an invalid value for Version. Error: Can't use PEP 440 local versions.", https://github.com/Zeroto521/my-data-toolkit/runs/4136766736?check_suite_focus=true
2. remove "dirty" in stable documentation