### PR TITLE
REV: "DOC: add edit page button"

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -96,7 +96,7 @@ moved_pages = [
 
 html_additional_pages = {page[0]: "redirect.html" for page in moved_pages}
 
-html_context = {"redirects": {old: new for old, new in moved_pages}}
+html_context = {"redirects": dict(moved_pages)}
 
 
 #  --Options for sphinx extensions -----------------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -73,7 +73,6 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "search_bar_position": "sidebar",
     "github_url": github_url,
-    "use_edit_page_button": True,
     "icon_links": [
         {
             "name": "PyPI",
@@ -97,13 +96,7 @@ moved_pages = [
 
 html_additional_pages = {page[0]: "redirect.html" for page in moved_pages}
 
-html_context = {
-    "redirects": dict(moved_pages),
-    "github_user": "zeroto521",
-    "github_repo": "my-data-toolkit",
-    "github_version": "master",
-    "doc_path": "doc",
-}
+html_context = {"redirects": {old: new for old, new in moved_pages}}
 
 
 #  --Options for sphinx extensions -----------------------------------------------


### PR DESCRIPTION
Reverts Zeroto521/my-data-toolkit#362

The **readthedocs** already support that.

![image](https://user-images.githubusercontent.com/25895405/148149049-ad9a18af-5759-4cfd-99d6-e08e562c21b6.png)

And #362 has bug, `doc_path` should change to `doc/source`.