### PR TITLE
CI: test dtoolkit compat with py3.11

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         dev: [true]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         env:
           - ci/envs/dev.yaml
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         dev: [true]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11.0-alpha - 3.11.0"]
         env:
           - ci/envs/dev.yaml
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #228
- [x] whatsnew entry

To know py3.11 has any conflict for dtoolkit.

When did PR#228, little parts of codes didn't compat with dtoolkit.
