### PR TITLE
EHN: let `register_*_method` support alias feature

### DIFF
--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -49,15 +49,13 @@ def register_method_factory(register_accessor):
         return wrapper
 
     @wraps(register_accessor)
-    def decorator(method_or_name: Callable | str | None = None):
-        if callable(method_or_name):  # Supports `@register_*_method` using.
-            return register_accessor_method(
-                method_or_name,
-                method_or_name.__name__,
-            )
+    def decorator(name: Callable | str | None = None):
+        if callable(name):  # Supports `@register_*_method` using.
+            method = name  # This 'name' variable actually is a function.
+            return register_accessor_method(method, method.__name__)
 
         # Supports `@register_*_method()` and `@register_*_method(name="")` using.
-        return register_accessor_alias(method_or_name)
+        return register_accessor_alias(name)
 
     return decorator
 

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -63,7 +63,7 @@ def register_method_factory(register_accessor):
 
 
 @register_method_factory
-@doc(klass=":class:`pandas.Series`")
+@doc(klass=":class:`~pandas.Series`")
 def register_series_method(name: str | None = None):
     """
     {klass} register accessor for human.
@@ -120,6 +120,6 @@ def register_series_method(name: str | None = None):
 
 
 @register_method_factory
-@doc(register_series_method, klass=":class:`pandas.DataFrame`")
+@doc(register_series_method, klass=":class:`~pandas.DataFrame`")
 def register_dataframe_method(name: str | None = None):
     return register_dataframe_accessor(name)

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -43,7 +43,7 @@ def register_method_factory(register_accessor):
     @wraps(register_accessor)
     def register_accessor_alias(name: str | None = None):
         @wraps(register_accessor)
-        def wrapper(method):
+        def wrapper(method: Callable):
             return register_accessor_method(method, name or method.__name__)
 
         return wrapper

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -61,11 +61,16 @@ def register_method_factory(register_accessor):
 
 @register_method_factory
 @doc(klass=":class:`pandas.Series`")
-def register_series_method(method):
+def register_series_method(name: str | None = None):
     """
     {klass} register accessor for human.
 
     Write method normally, use method naturally.
+
+    Parameters
+    ----------
+    name : str, optional
+        Use the ``method`` name as the default accessor entrance if ``name`` is None.
 
     See Also
     --------
@@ -108,10 +113,10 @@ def register_series_method(method):
         Out[4]:
         'a'
     """
-    return register_series_accessor(method)
+    return register_series_accessor(name)
 
 
 @register_method_factory
 @doc(register_series_method, klass=":class:`pandas.DataFrame`")
-def register_dataframe_method(method):
-    return register_dataframe_accessor(method)
+def register_dataframe_method(name: str | None = None):
+    return register_dataframe_accessor(name)

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -88,8 +88,10 @@ def register_series_method(name: str | None = None):
 
         import pandas as pd
 
+        @register_dataframe_method(name="col")
+        @register_series_method(name="col")  # Support alias name also.
         @register_dataframe_method
-        @register_series_method
+        @register_series_method  # Use accessor method `__name__` as the entrance.
         def cols(pd_obj):
             '''
             An API to gather :attr:`~pandas.Series.name` and
@@ -114,6 +116,14 @@ def register_series_method(name: str | None = None):
 
         In [4]: df.a.cols()
         Out[4]:
+        'a'
+
+        In [5]: df.col()
+        Out[5]:
+        ['a', 'b']
+
+        In [6]: df.a.col()
+        Out[6]:
         'a'
     """
     return register_series_accessor(name)

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -49,12 +49,14 @@ def register_method_factory(register_accessor):
         return wrapper
 
     @wraps(register_accessor)
-    def decorator(name: Callable | str | None = None):
-        if callable(name):
-            method = name  # This 'name' variable actually is a function.
-            return register_accessor_method(method, method.__name__)
+    def decorator(method_or_name: Callable | str | None = None):
+        if callable(method_or_name):
+            return register_accessor_method(
+                method_or_name,
+                method_or_name.__name__,
+            )
 
-        return register_accessor_alias(name)
+        return register_accessor_alias(method_or_name)
 
     return decorator
 

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -21,6 +21,8 @@ def register_method_factory(register_accessor):
     --------
     register_series_method
     register_dataframe_method
+    dtoolkit.geoaccessor.register_geoseries_method
+    dtoolkit.geoaccessor.register_geodataframe_method
     """
 
     # based on pandas_flavor/register.py

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -50,12 +50,13 @@ def register_method_factory(register_accessor):
 
     @wraps(register_accessor)
     def decorator(method_or_name: Callable | str | None = None):
-        if callable(method_or_name):
+        if callable(method_or_name):  # Supports `@register_*_method` using.
             return register_accessor_method(
                 method_or_name,
                 method_or_name.__name__,
             )
 
+        # Supports `@register_*_method()` and `@register_*_method(name="")` using.
         return register_accessor_alias(method_or_name)
 
     return decorator

--- a/dtoolkit/geoaccessor/accessor.py
+++ b/dtoolkit/geoaccessor/accessor.py
@@ -1,10 +1,9 @@
-from geopandas import GeoDataFrame
-from geopandas import GeoSeries
+import geopandas as gpd
 from pandas.core.accessor import _register_accessor
 from pandas.util._decorators import doc
 
 
-@doc(klass=":class:`geopandas.GeoSeries`")
+@doc(klass=":class:`~geopandas.GeoSeries`")
 def register_geoseries_accessor(name: str):
     """
     Register a custom accessor on {klass} objects.
@@ -108,10 +107,10 @@ def register_geoseries_accessor(name: str):
         Name: geometry, dtype: int64
     """
 
-    return _register_accessor(name, GeoSeries)
+    return _register_accessor(name, gpd.GeoSeries)
 
 
-@doc(register_geoseries_accessor, klass=":class:`geopandas.GeoDataFrame`")
+@doc(register_geoseries_accessor, klass=":class:`~geopandas.GeoDataFrame`")
 def register_geodataframe_accessor(name: str):
 
-    return _register_accessor(name, GeoDataFrame)
+    return _register_accessor(name, gpd.GeoDataFrame)

--- a/dtoolkit/geoaccessor/register.py
+++ b/dtoolkit/geoaccessor/register.py
@@ -35,8 +35,10 @@ def register_geoseries_method(name: str | None = None):
 
         from pygeos import count_coordinates, from_shapely
 
+        @register_geodataframe_method(name="count_it")
+        @register_geoseries_method(name="count_it")  # Support alias name also.
         @register_geodataframe_method
-        @register_geoseries_method
+        @register_geoseries_method  # Use accessor method `__name__` as the entrance.
         def counts(s: gpd.GeoSeries):
             # Counts the number of coordinate pairs in geometry
 
@@ -78,6 +80,21 @@ def register_geoseries_method(name: str | None = None):
         1    1
         2    0
         Name: geometry, dtype: int64
+        
+        In [7]: s.count_it()
+        Out[7]:
+        0    1
+        1    1
+        2    0
+        dtype: int64
+
+        In [8]: d.count_it()
+        Out[8]:
+        0    1
+        1    1
+        2    0
+        Name: geometry, dtype: int64
+
     """
     return register_geoseries_accessor(name)
 

--- a/dtoolkit/geoaccessor/register.py
+++ b/dtoolkit/geoaccessor/register.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pandas.util._decorators import doc
 
 from dtoolkit.accessor.register import register_method_factory
@@ -6,12 +8,17 @@ from dtoolkit.geoaccessor.accessor import register_geoseries_accessor
 
 
 @register_method_factory
-@doc(klass=":class:`geopandas.GeoSeries`")
-def register_geoseries_method(method):
+@doc(klass=":class:`~geopandas.GeoSeries`")
+def register_geoseries_method(name: str | None = None):
     """
     {klass} register accessor for human.
 
     Write method normally, use method naturally.
+
+    Parameters
+    ----------
+    name : str, optional
+        Use the ``method`` name as the default accessor entrance if ``name`` is None.
 
     See Also
     --------
@@ -72,10 +79,10 @@ def register_geoseries_method(method):
         2    0
         Name: geometry, dtype: int64
     """
-    return register_geoseries_accessor(method)
+    return register_geoseries_accessor(name)
 
 
 @register_method_factory
-@doc(register_geoseries_method, klass=":class:`geopandas.GeoDataFrame`")
-def register_geodataframe_method(method):
-    return register_geodataframe_accessor(method)
+@doc(register_geoseries_method, klass=":class:`~geopandas.GeoDataFrame`")
+def register_geodataframe_method(name: str | None = None):
+    return register_geodataframe_accessor(name)

--- a/dtoolkit/geoaccessor/register.py
+++ b/dtoolkit/geoaccessor/register.py
@@ -80,7 +80,7 @@ def register_geoseries_method(name: str | None = None):
         1    1
         2    0
         Name: geometry, dtype: int64
-        
+
         In [7]: s.count_it()
         Out[7]:
         0    1

--- a/test/accessor/test_register.py
+++ b/test/accessor/test_register.py
@@ -54,8 +54,8 @@ df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
         (df.a, "names"),
         (df, "names_1"),
         (df.a, "names_1"),
-        # (df, "name_or_columns"),
-        # (df.a, "name_or_columns"),
+        (df, "name_or_columns"),
+        (df.a, "name_or_columns"),
     ],
 )
 def test_method_hooked_exist(data, name):

--- a/test/accessor/test_register.py
+++ b/test/accessor/test_register.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.accessor.register import register_series_method
@@ -17,14 +18,84 @@ def names(pd_obj):
     return pd_obj.columns.tolist()
 
 
+@register_dataframe_method()
+@register_series_method()
+def names_1(pd_obj):
+    """
+    An API to gather :attr:`~pandas.Series.name` and
+    :attr:`~pandas.DataFrame.columns` to one.
+    """
+    if isinstance(pd_obj, pd.Series):
+        return pd_obj.name
+
+    return pd_obj.columns.tolist()
+
+
+@register_dataframe_method(name="name_or_columns")
+@register_series_method(name="name_or_columns")
+def names_2(pd_obj):
+    """
+    An API to gather :attr:`~pandas.Series.name` and
+    :attr:`~pandas.DataFrame.columns` to one.
+    """
+    if isinstance(pd_obj, pd.Series):
+        return pd_obj.name
+
+    return pd_obj.columns.tolist()
+
+
 df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 
 
-def test_method_hooked():
-    assert hasattr(df, "names")
-    assert hasattr(df.a, "names")
+@pytest.mark.parametrize(
+    "data, name",
+    [
+        (df, "names"),
+        (df.a, "names"),
+        (df, "names_1"),
+        (df.a, "names_1"),
+        # (df, "name_or_columns"),
+        # (df.a, "name_or_columns"),
+    ],
+)
+def test_method_hooked_exist(data, name):
+    assert hasattr(data, name)
 
 
-def test_work():
-    assert df.names() == ["a", "b"]
-    assert df.a.names() == "a"
+@pytest.mark.parametrize(
+    "data, name, excepted",
+    [
+        (df, "names", ["a", "b"]),
+        (df.a, "names", "a"),
+        (df, "names_1", ["a", "b"]),
+        (df.a, "names_1", "a"),
+        (df, "name_or_columns", ["a", "b"]),
+        (df.a, "name_or_columns", "a"),
+    ],
+)
+def test_work(data, name, excepted):
+    result = getattr(data, name)()
+
+    assert result == excepted
+
+
+@pytest.mark.parametrize(
+    "data, name, attr, excepted",
+    [
+        (df, "names", "__name__", names.__name__),
+        (df.a, "names", "__name__", names.__name__),
+        (df, "names", "__doc__", names.__doc__),
+        (df.a, "names", "__doc__", names.__doc__),
+        (df, "names_1", "__name__", names_1.__name__),
+        (df.a, "names_1", "__name__", names_1.__name__),
+        (df, "names_1", "__doc__", names_1.__doc__),
+        (df.a, "names_1", "__doc__", names_1.__doc__),
+        (df, "name_or_columns", "__doc__", names_2.__doc__),
+        (df.a, "name_or_columns", "__doc__", names_2.__doc__),
+    ],
+)
+def test_method_hooked_attr(data, name, attr, excepted):
+    method = getattr(data, name)
+    result = getattr(method, attr)
+
+    assert result == excepted


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #379 and #282
- [x] whatsnew entry

This could use accessor easier, e.g. `Series.lens` -> `Series.len`, `Series.get_attr` -> `Series.getattr`.
Before this PR, `len` is a python keyword, so it can't use `len` as the method name.
This PR will cause v0.0.9 version delay.