### PR TITLE
DOC: specific the using between `default None` and `optional`

### DIFF
--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -320,7 +320,7 @@ def expand(
 
     Parameters
     ----------
-    suffix : list of str or int, default None
+    suffix : list of str or int, optional
         New columns of return :class:`~pandas.DataFrame`.
 
     delimiter : str, default "_"
@@ -430,7 +430,7 @@ def error_report(
     ----------
     predicted : list of int or float, ndarrray, Series
         A array is compared to ``s``.
-    columns : list of str or int, default None
+    columns : list of str or int, optional
         The columns of returning DataFrame, each represents `true value`,
         `predicted value`, `absolute error`, and `relative error`.
 

--- a/dtoolkit/util/generic.py
+++ b/dtoolkit/util/generic.py
@@ -19,7 +19,7 @@ def multi_if_else(
     if_condition_return : list[tuple(bool, Any)]
         Array of tuple contains the condition and result. if the return is
         :obj:`Exception` would raise a error.
-    else_return : Any, default is None
+    else_return : Any, default None
         The final returning result, if the result is :obj:`Exception` would
         raise an error.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Some places should use `optional` better than `default None`, some don't.
