### PR TITLE
DOC: delay release v0.0.9 to 22/1/10 + record new features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 0.0.9] (2022-1-7)
+## [Version 0.0.9] (2022-1-10)
 
 Use `squash merge` to keep a cleaning git commit history ({issue}`386`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@
 
 Use `squash merge` to keep a cleaning git commit history ({issue}`386`).
 
+Highlights of this release:
+
+- {meth}`~dtoolkit.accessor.register_series_method` and {meth}`~dtoolkit.accessor.register_dataframe_method` support alias ({pr}`392`).
+
 New features and improvements:
 
 - {meth}`~dtoolkit.geoaccessor.dataframe.points_from_xy` would return `GeoSeries` if df only has one column ({pr}`385`).
 - New accessor method {meth}`~dtoolkit.accessor.dataframe.to_series` ({pr}`380`).
-- New accessor method {meth}`~dtoolkit.accessor.series.get_attr` ({pr}`379`).
+- New accessor method {meth}`~dtoolkit.accessor.series.get_attr` ({pr}`379`, {pr}`394`).
+
+API changes:
+
+- Call {meth}`~dtoolkit.accessor.series.lens` via `Series.len` ({pr}`394`).
 
 Maintenance development:
 

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -377,6 +377,7 @@ def lens(s: pd.Series) -> pd.Series:
 
         Call this method via ``Series.lens()`` is deprecated and will be removed
         in **0.0.10**. Please call it via ``Series.len()`` instead.
+        (Warning added DToolKit **0.0.9**)
 
     Return the length of each element in the series.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #392 and #379
- [x] whatsnew entry

Due to PR#392 coming up with some new features, version 0.0.9 will delay release till 22/1/10.
The main reason is to change calling PR#379 `get_attr` method, from `Series.get_attr` to `Series.getattr`