### PR TITLE
CI: draft github-action release then add changelog by manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Upload Release Asset to GitHub
         uses: softprops/action-gh-release@v1
         with:
+          draft: true
           files: dist/${{ needs.build.outputs.tar }}
 
   publish-to-pypi:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ API changes:
 
 Maintenance development:
 
+- Draft github-action release then add changelog by manually ({pr}`396`).
 - Fix words, a -> an ({pr}`387`).
 - Pre-commit hooks autoupdate ({pr}`384`).
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

github-action only releases file, don't have any changelogs.
So save a draft version then edit manually.