### PR TITLE
MAINT: call method `Series.get_attr` via function name is ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New features and improvements:
 
 - {meth}`~dtoolkit.geoaccessor.dataframe.points_from_xy` would return `GeoSeries` if df only has one column ({pr}`385`).
 - New accessor method {meth}`~dtoolkit.accessor.dataframe.to_series` ({pr}`380`).
-- New accessor method {meth}`~dtoolkit.accessor.series.get_attr` ({pr}`379`, {pr}`394`).
+- New accessor method {meth}`~dtoolkit.accessor.series.get_attr` ({pr}`379`, {pr}`394`, {pr}`398`).
 
 API changes:
 

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -392,7 +392,7 @@ def lens(s: pd.Series) -> pd.Series:
     Notes
     -----
     To keep the Python naming style, so use this accessor via
-    ``Series.len`` not ``Series.lens``.
+    ``Series.len`` rather than ``Series.lens``.
 
     Examples
     --------
@@ -560,7 +560,7 @@ def get_attr(s: pd.Series, name: str, *args, **kwargs) -> pd.Series:
     Notes
     -----
     To keep the Python naming style, so use this accessor via
-    ``Series.getattr`` not ``Series.get_attr``.
+    ``Series.getattr`` rather than ``Series.get_attr``.
 
     Examples
     --------

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -534,6 +534,7 @@ def error_report(
 
 
 @register_series_method(name="getattr")
+@register_series_method
 def get_attr(s: pd.Series, name: str, *args, **kwargs) -> pd.Series:
     """
     Return the value of the named attribute of Series element.


### PR DESCRIPTION
- [x] closes #379 and #392
- [x] whatsnew entry

Prefer to call `Series.getattr()` rather then `Series.get_attr()`, but the function name is `get_attr`. It would be a little weird. 
So call `Series.getattr()` is ok, but not recommended.