### PR TITLE
EHN: add `number` and `other` option for `Series.len`

### DIFF
--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -381,9 +381,9 @@ def lens(s: pd.Series, number: int | None = 1, other: int | None = None) -> pd.S
     Parameters
     ----------
     number : int or None, default '1'
-        The default length of `number` type. 
+        The default length of `number` type.
     other : int or None, default None
-        The default length of `other` type. 
+        The default length of `other` type.
 
     Returns
     -------

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -371,7 +371,7 @@ def expand(
 
 @register_series_method(name="len")
 @register_series_method
-def lens(s: pd.Series) -> pd.Series:
+def lens(s: pd.Series, number: int | None = 1, other: int | None = None) -> pd.Series:
     """
     .. warning::
 
@@ -381,9 +381,15 @@ def lens(s: pd.Series) -> pd.Series:
 
     Return the length of each element in the series.
 
-    Equals to::
+    Equals to ``s.apply(len)``, but the length of ``number`` type will as ``1``,
+    the length of other types will as ``NaN``.
 
-        s.apply(len)
+    Parameters
+    ----------
+    number : int or None, default '1'
+        The default length of `number` type. 
+    other : int or None, default None
+        The default length of `other` type. 
 
     Returns
     -------
@@ -391,8 +397,11 @@ def lens(s: pd.Series) -> pd.Series:
 
     Notes
     -----
-    To keep the Python naming style, so use this accessor via
-    ``Series.len`` not ``Series.lens``.
+    - To keep the Python naming style, so use this accessor via
+      ``Series.len`` not ``Series.lens``.
+
+    - Different to :meth:`pandas.Series.str.len`. It only returns
+      :class:`collections.abc.Iterable` type length. Other type will return `NaN`.
 
     Examples
     --------
@@ -434,7 +443,9 @@ def lens(s: pd.Series) -> pd.Series:
         if hasattr(x, "__len__"):
             return len(x)
         elif is_number(x):
-            return 1
+            return number
+        else:
+            return other
 
     return s.apply(wrap_len)
 

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -426,6 +426,18 @@ def lens(s: pd.Series, number: int | None = 1, other: int | None = None) -> pd.S
     5    0.0
     6    NaN
     dtype: float64
+
+    Set `number` and `other` default return.
+
+    >>> s.len(number=0, other=0)
+    0    0
+    1    0
+    2    6
+    3    1
+    4    1
+    5    0
+    6    0
+    dtype: int64
     """
     from warnings import warn
 

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -392,7 +392,7 @@ def lens(s: pd.Series, number: int | None = 1, other: int | None = None) -> pd.S
     Notes
     -----
     - To keep the Python naming style, so use this accessor via
-      ``Series.len`` not ``Series.lens``.
+      ``Series.len`` rather than ``Series.lens``.
 
     - Different to :meth:`pandas.Series.str.len`. It only returns
       :class:`collections.abc.Iterable` type length. Other type will return `NaN`.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

None-number type supports return arbitrary length.
