### PR TITLE
BUG: add ipykernel to fix notebook error

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -14,7 +14,9 @@ dependencies:
   - myst-parser
   - numpydoc
   - ipython
+  # jupyter
   - nbsphinx
+  - ipykernel
   - pip
   - pip:
       - sphinx-toggleprompt

--- a/doc/source/guide/build_transformer.ipynb
+++ b/doc/source/guide/build_transformer.ipynb
@@ -121,6 +121,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/doc/source/guide/tips_about_getattr.ipynb
+++ b/doc/source/guide/tips_about_getattr.ipynb
@@ -340,6 +340,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/doc/source/guide/transformer_quickstart.ipynb
+++ b/doc/source/guide/transformer_quickstart.ipynb
@@ -636,6 +636,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",


### PR DESCRIPTION
https://readthedocs.org/projects/my-data-toolkit/builds/15723946/

Notebook error:
NoSuchKernel in guide/build_transformer.ipynb:
No such kernel named python3

<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #405
- [x] whatsnew entry
