### PR TITLE
REV: "CI: update hook chinthakagodawita/autoupdate-action version"

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -8,7 +8,7 @@ jobs:
   branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker://chinthakagodawita/autoupdate-action:v1.6.0
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
         id: branch
         env:
           GITHUB_TOKEN: ${{ secrets.PERSON_GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts Zeroto521/my-data-toolkit#415

v1.6.0 couldn't work.

https://github.com/Zeroto521/my-data-toolkit/runs/4770391746?check_suite_focus=true

Error response from daemon: manifest for chinthakagodawita/autoupdate-action:v1.6.0 not found: manifest unknown: manifest unknown