### PR TITLE
EHN: `register_*_method` could register class

### DIFF
--- a/test/accessor/test_register.py
+++ b/test/accessor/test_register.py
@@ -5,6 +5,13 @@ from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.accessor.register import register_series_method
 
 
+def base_names(pd_obj):
+    if isinstance(pd_obj, pd.Series):
+        return pd_obj.name
+
+    return pd_obj.columns.tolist()
+
+
 @register_dataframe_method
 @register_series_method
 def names(pd_obj):
@@ -12,10 +19,8 @@ def names(pd_obj):
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
     """
-    if isinstance(pd_obj, pd.Series):
-        return pd_obj.name
 
-    return pd_obj.columns.tolist()
+    return base_names(pd_obj)
 
 
 @register_dataframe_method()
@@ -25,10 +30,8 @@ def names_1(pd_obj):
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
     """
-    if isinstance(pd_obj, pd.Series):
-        return pd_obj.name
 
-    return pd_obj.columns.tolist()
+    return base_names(pd_obj)
 
 
 @register_dataframe_method(name="name_or_columns")
@@ -38,10 +41,8 @@ def names_2(pd_obj):
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
     """
-    if isinstance(pd_obj, pd.Series):
-        return pd_obj.name
 
-    return pd_obj.columns.tolist()
+    return base_names(pd_obj)
 
 
 df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})

--- a/test/accessor/test_register.py
+++ b/test/accessor/test_register.py
@@ -14,7 +14,7 @@ def base_names(pd_obj):
 
 @register_dataframe_method
 @register_series_method
-def names(pd_obj):
+def method_names(pd_obj):
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
@@ -25,7 +25,7 @@ def names(pd_obj):
 
 @register_dataframe_method()
 @register_series_method()
-def names_1(pd_obj):
+def method_names_1(pd_obj):
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
@@ -34,9 +34,9 @@ def names_1(pd_obj):
     return base_names(pd_obj)
 
 
-@register_dataframe_method(name="name_or_columns")
-@register_series_method(name="name_or_columns")
-def names_2(pd_obj):
+@register_dataframe_method(name="method_name_or_columns")
+@register_series_method(name="method_name_or_columns")
+def method_names_2(pd_obj):
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
@@ -45,75 +45,211 @@ def names_2(pd_obj):
     return base_names(pd_obj)
 
 
-@register_dataframe_method("name_or_columns_1")
-@register_series_method("name_or_columns_1")
-def names_3(pd_obj):
+@register_dataframe_method("method_name_or_columns_1")
+@register_series_method("method_name_or_columns_1")
+def method_names_3(pd_obj):
+
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
     """
 
     return base_names(pd_obj)
+
+
+class base_class:
+    def __init__(self, pd_obj):
+        self.pd_obj = pd_obj
+
+
+@register_dataframe_method
+@register_series_method
+class class_names(base_class):
+    def attr_property(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+    def attr_method(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+
+@register_dataframe_method()
+@register_series_method()
+class class_names_1(base_class):
+    def attr_property(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+    def attr_method(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+
+@register_dataframe_method(name="class_name_or_columns")
+@register_series_method(name="class_name_or_columns")
+class class_names_2(base_class):
+    def attr_property(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+    def attr_method(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+
+@register_dataframe_method("class_name_or_columns_1")
+@register_series_method("class_name_or_columns_1")
+class class_names_3(base_class):
+    def attr_property(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
+
+    def attr_method(self):
+        """
+        An API to gather :attr:`~pandas.Series.name` and
+        :attr:`~pandas.DataFrame.columns` to one.
+        """
+
+        return base_names(self.pd_obj)
 
 
 df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 
 
-@pytest.mark.parametrize(
-    "data, name",
-    [
-        (df, "names"),
-        (df.a, "names"),
-        (df, "names_1"),
-        (df.a, "names_1"),
-        (df, "name_or_columns"),
-        (df.a, "name_or_columns"),
-        (df, "name_or_columns_1"),
-        (df.a, "name_or_columns_1"),
-    ],
-)
-def test_method_hooked_exist(data, name):
-    assert hasattr(data, name)
+class TestMethod:
+    @pytest.mark.parametrize(
+        "data, name",
+        [
+            (df, "method_names"),
+            (df.a, "method_names"),
+            (df, "method_names_1"),
+            (df.a, "method_names_1"),
+            (df, "method_name_or_columns"),
+            (df.a, "method_name_or_columns"),
+            (df, "method_name_or_columns_1"),
+            (df.a, "method_name_or_columns_1"),
+        ],
+    )
+    def test_method_hooked_exist(self, data, name):
+        assert hasattr(data, name)
+
+    @pytest.mark.parametrize(
+        "data, name, excepted",
+        [
+            (df, "method_names", ["a", "b"]),
+            (df.a, "method_names", "a"),
+            (df, "method_names_1", ["a", "b"]),
+            (df.a, "method_names_1", "a"),
+            (df, "method_name_or_columns", ["a", "b"]),
+            (df.a, "method_name_or_columns", "a"),
+            (df, "method_name_or_columns_1", ["a", "b"]),
+            (df.a, "method_name_or_columns_1", "a"),
+        ],
+    )
+    def test_work(self, data, name, excepted):
+        result = getattr(data, name)()
+
+        assert result == excepted
+
+    @pytest.mark.parametrize(
+        "data, name, attr, excepted",
+        [
+            (df, "method_names", "__name__", method_names.__name__),
+            (df.a, "method_names", "__name__", method_names.__name__),
+            (df, "method_names", "__doc__", method_names.__doc__),
+            (df.a, "method_names", "__doc__", method_names.__doc__),
+            (df, "method_names_1", "__name__", method_names_1.__name__),
+            (df.a, "method_names_1", "__name__", method_names_1.__name__),
+            (df, "method_names_1", "__doc__", method_names_1.__doc__),
+            (df.a, "method_names_1", "__doc__", method_names_1.__doc__),
+            (df, "method_name_or_columns", "__name__", method_names_2.__name__),
+            (df.a, "method_name_or_columns", "__name__", method_names_2.__name__),
+            (df, "method_name_or_columns", "__doc__", method_names_2.__doc__),
+            (df.a, "method_name_or_columns", "__doc__", method_names_2.__doc__),
+            (df, "method_name_or_columns_1", "__name__", method_names_3.__name__),
+            (df.a, "method_name_or_columns_1", "__name__", method_names_3.__name__),
+            (df, "method_name_or_columns_1", "__doc__", method_names_3.__doc__),
+            (df.a, "method_name_or_columns_1", "__doc__", method_names_3.__doc__),
+        ],
+    )
+    def test_method_hooked_attr(self, data, name, attr, excepted):
+        method = getattr(data, name)
+        result = getattr(method, attr)
+
+        assert result == excepted
 
 
-@pytest.mark.parametrize(
-    "data, name, excepted",
-    [
-        (df, "names", ["a", "b"]),
-        (df.a, "names", "a"),
-        (df, "names_1", ["a", "b"]),
-        (df.a, "names_1", "a"),
-        (df, "name_or_columns", ["a", "b"]),
-        (df.a, "name_or_columns", "a"),
-        (df, "name_or_columns_1", ["a", "b"]),
-        (df.a, "name_or_columns_1", "a"),
-    ],
-)
-def test_work(data, name, excepted):
-    result = getattr(data, name)()
+class TestClass:
+    @pytest.mark.parametrize(
+        "data, name",
+        [
+            (df, "class_names"),
+            (df.a, "class_names"),
+            (df, "class_names_1"),
+            (df.a, "class_names_1"),
+            (df, "class_name_or_columns"),
+            (df.a, "class_name_or_columns"),
+            (df, "class_name_or_columns_1"),
+            (df.a, "class_name_or_columns_1"),
+        ],
+    )
+    def test_class_hooked_exist(self, data, name):
+        assert hasattr(data, name)
 
-    assert result == excepted
+    @pytest.mark.parametrize(
+        "data, name, attr, excepted",
+        [
+            (df, "class_names", "attr_property", ["a", "b"]),
+            (df.a, "class_names", "attr_property", "a"),
+            (df, "class_names_1", "attr_property", ["a", "b"]),
+            (df.a, "class_names_1", "attr_property", "a"),
+            (df, "class_name_or_columns", "attr_property", ["a", "b"]),
+            (df.a, "class_name_or_columns", "attr_property", "a"),
+            (df, "class_name_or_columns_1", "attr_property", ["a", "b"]),
+            (df.a, "class_name_or_columns_1", "attr_property", "a"),
+            (df, "class_names", "attr_method", ["a", "b"]),
+            (df.a, "class_names", "attr_method", "a"),
+            (df, "class_names_1", "attr_method", ["a", "b"]),
+            (df.a, "class_names_1", "attr_method", "a"),
+            (df, "class_name_or_columns", "attr_method", ["a", "b"]),
+            (df.a, "class_name_or_columns", "attr_method", "a"),
+            (df, "class_name_or_columns_1", "attr_method", ["a", "b"]),
+            (df.a, "class_name_or_columns_1", "attr_method", "a"),
+        ],
+    )
+    def test_work(self, data, name, attr, excepted):
+        method = getattr(data, name)
+        result = getattr(method, attr)
+        if callable(result):
+            result = result()
 
-
-@pytest.mark.parametrize(
-    "data, name, attr, excepted",
-    [
-        (df, "names", "__name__", names.__name__),
-        (df.a, "names", "__name__", names.__name__),
-        (df, "names", "__doc__", names.__doc__),
-        (df.a, "names", "__doc__", names.__doc__),
-        (df, "names_1", "__name__", names_1.__name__),
-        (df.a, "names_1", "__name__", names_1.__name__),
-        (df, "names_1", "__doc__", names_1.__doc__),
-        (df.a, "names_1", "__doc__", names_1.__doc__),
-        (df, "name_or_columns", "__doc__", names_2.__doc__),
-        (df.a, "name_or_columns", "__doc__", names_2.__doc__),
-        (df, "name_or_columns_1", "__doc__", names_2.__doc__),
-        (df.a, "name_or_columns_1", "__doc__", names_2.__doc__),
-    ],
-)
-def test_method_hooked_attr(data, name, attr, excepted):
-    method = getattr(data, name)
-    result = getattr(method, attr)
-
-    assert result == excepted
+        assert result == excepted

--- a/test/accessor/test_register.py
+++ b/test/accessor/test_register.py
@@ -45,6 +45,17 @@ def names_2(pd_obj):
     return base_names(pd_obj)
 
 
+@register_dataframe_method("name_or_columns_1")
+@register_series_method("name_or_columns_1")
+def names_3(pd_obj):
+    """
+    An API to gather :attr:`~pandas.Series.name` and
+    :attr:`~pandas.DataFrame.columns` to one.
+    """
+
+    return base_names(pd_obj)
+
+
 df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
 
 
@@ -57,6 +68,8 @@ df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
         (df.a, "names_1"),
         (df, "name_or_columns"),
         (df.a, "name_or_columns"),
+        (df, "name_or_columns_1"),
+        (df.a, "name_or_columns_1"),
     ],
 )
 def test_method_hooked_exist(data, name):
@@ -72,6 +85,8 @@ def test_method_hooked_exist(data, name):
         (df.a, "names_1", "a"),
         (df, "name_or_columns", ["a", "b"]),
         (df.a, "name_or_columns", "a"),
+        (df, "name_or_columns_1", ["a", "b"]),
+        (df.a, "name_or_columns_1", "a"),
     ],
 )
 def test_work(data, name, excepted):
@@ -93,6 +108,8 @@ def test_work(data, name, excepted):
         (df.a, "names_1", "__doc__", names_1.__doc__),
         (df, "name_or_columns", "__doc__", names_2.__doc__),
         (df.a, "name_or_columns", "__doc__", names_2.__doc__),
+        (df, "name_or_columns_1", "__doc__", names_2.__doc__),
+        (df.a, "name_or_columns_1", "__doc__", names_2.__doc__),
     ],
 )
 def test_method_hooked_attr(data, name, attr, excepted):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

This PR is to record this idea.
It almost wouldn't be merged into the 'main' branch. Because `pandas.api.extensions.register_*_accessor` already could register class.