### PR TITLE
BUG/DOC: correct jupyter link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Small bug-fix:
 
-- Fix jupyer notebook can't render ({pr}`438`).
+- Fix jupyter notebook can't render ({pr}`438`).
 
 New features and improvements:
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -130,8 +130,6 @@ extlinks = {
     "issue": (f"{github_url}/issues/%s", "issue#"),
     "pr": (f"{github_url}/issues/%s", "pr#"),
     "user": (r"https://github.com/%s", "@"),
-    # github's link
-    "ghlink": (r"https://github.com/%s", None),
 }
 
 myst_enable_extensions = [

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,7 +107,7 @@ nbsphinx_prolog = r"""
 
     This page was generated from `{{ docname }}`__.
 
-    __ :ghlink:`my-data-toolkit/blob/main/doc/source/{{ docname }}`
+    __ https://github.com/zeroto521/my-data-toolkit/blob/main/doc/source/{{ docname }}
 """
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,8 +21,8 @@ Useful Links
 `Binary Installers (PyPI)`_ | `Source Repository (GitHub)`_ | `Issues & Ideas`_
 
 .. _Binary Installers (PyPI): https://pypi.org/project/my-data-toolkit
-.. _Source Repository (GitHub): :ghlink:`Zeroto521/my-data-toolkit``
-.. _Issues & Ideas: :ghlink:`Zeroto521/my-data-toolkit/issues`
+.. _Source Repository (GitHub): https://github.com/Zeroto521/my-data-toolkit
+.. _Issues & Ideas: https://github.com/Zeroto521/my-data-toolkit/issues
 
 
 Indices and Tables

--- a/dtoolkit/geoaccessor/accessor.py
+++ b/dtoolkit/geoaccessor/accessor.py
@@ -13,7 +13,7 @@ def register_geoseries_accessor(name: str):
     If `geopandas#1952`_ done, it would be removed from
     :mod:`dtoolkit.geoaccessor`.
 
-    .. _geopandas#1952: :ghlink:`geopandas/geopandas/pull/1952`
+    .. _geopandas#1952: https://github.com/geopandas/geopandas/pull/1952
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #438
- [x] whatsnew entry

[guide/transformer_quickstart.ipynb](https://my-data-toolkit.readthedocs.io/en/v0.0.11/guide/transformer_quickstart.html) link is https://my-data-toolkit.readthedocs.io/en/v0.0.11/guide/:ghlink:%60my-data-toolkit/blob/main/doc/source/guide/transformer_quickstart.ipynb%60

It's not right.
