### PR TITLE
DEP: add `DeprecationWarning` for `dtoolkit.transformer.MinMaxScaler`

### DIFF
--- a/dtoolkit/transformer/sklearn.py
+++ b/dtoolkit/transformer/sklearn.py
@@ -26,6 +26,12 @@ class MinMaxScaler(SKMinMaxScaler):
     """
     Transform features by scaling each feature to a given range.
 
+    .. warning::
+        Transformer :class:`dtoolkit.transformer.MinMaxScaler` is deprecated and
+        will be removed in 0.0.13.
+        Please use :class:`sklearn.preprocessing.MinMaxScaler` instead.
+        (Warning added DToolKit 0.0.12)
+
     The transformation is given by::
 
         X_std = (X - X.min(axis=0)) / (X.max(axis=0) - X.min(axis=0))
@@ -56,6 +62,20 @@ class MinMaxScaler(SKMinMaxScaler):
     This would let :obj:`~pandas.DataFrame` in and
     :obj:`~pandas.DataFrame` out.
     """
+
+    @doc(SKMinMaxScaler.__init__)
+    def __init__(self, *args, **kwargs):
+        from warnings import warn
+
+        warn(
+            "Transformer 'dtoolkit.transformer.MinMaxScaler' is deprecated and "
+            "will be removed in 0.0.13. "
+            "Please use 'sklearn.preprocessing.MinMaxScaler' instead. "
+            "(Warning added DToolKit 0.0.12)",
+            DeprecationWarning,
+        )
+
+        super().__init__(*args, **kwargs)
 
     @doc(SKMinMaxScaler.fit)
     def fit(self, X, y=None):

--- a/dtoolkit/transformer/sklearn.py
+++ b/dtoolkit/transformer/sklearn.py
@@ -64,7 +64,7 @@ class MinMaxScaler(SKMinMaxScaler):
     """
 
     @doc(SKMinMaxScaler.__init__)
-    def __init__(self, *args, **kwargs):
+    def __init__(self, feature_range=(0, 1), *, copy=True, clip=False):
         from warnings import warn
 
         warn(
@@ -75,7 +75,11 @@ class MinMaxScaler(SKMinMaxScaler):
             DeprecationWarning,
         )
 
-        super().__init__(*args, **kwargs)
+        super().__init__(
+            feature_range=feature_range,
+            copy=copy,
+            clip=clip,
+        )
 
     @doc(SKMinMaxScaler.fit)
     def fit(self, X, y=None):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #431
- [x] whatsnew entry

Since PR#431 has been done, `dtoolkit.transformer.MinMaxScaler` is duplicated to `sklearn.preprocessing.MinMaxScaler` in functional way.