### PR TITLE
TST: handle `GeoSeries` FutureWarning

### DIFF
--- a/test/accessor/test_dataframe.py
+++ b/test/accessor/test_dataframe.py
@@ -519,7 +519,7 @@ class TestToSeries:
             (
                 gpd.GeoDataFrame({"a": [1, 2]}),
                 None,
-                gpd.GeoSeries([1, 2], name="a"),
+                pd.Series([1, 2], name="a"),
             ),
             # geodataframe -> geoseries
             (


### PR DESCRIPTION
FutureWarning: You are passing non-geometry data to the GeoSeries constructor. Currently, it falls back to returning a pandas Series. But in the future, we will start to raise a TypeError instead. gpd.GeoSeries([1, 2], name="a"),

<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry
