### PR TITLE
BUG:  Let `Pipeline`'s `fit_transform` supports `Series`

### DIFF
--- a/dtoolkit/transformer/pipeline.py
+++ b/dtoolkit/transformer/pipeline.py
@@ -86,8 +86,9 @@ class Pipeline(SKPipeline):
     def fit_transform(self, X, y=None, **fit_params):
         fit_params_steps = self._check_fit_params(**fit_params)
 
-        X = transform_series_to_frame(X)
+        X = transform_series_to_frame(X)  # transform fit's input to DataFrame
         X = self._fit(X, y, **fit_params_steps)
+        X = transform_series_to_frame(X)  # transofrm fit's output to DataFrame
 
         last_step = self._final_estimator
         with _print_elapsed_time("Pipeline", self._log_message(len(self.steps) - 1)):

--- a/dtoolkit/transformer/pipeline.py
+++ b/dtoolkit/transformer/pipeline.py
@@ -101,7 +101,8 @@ class Pipeline(SKPipeline):
             else:
                 Xt = last_step.fit(X, y, **fit_params_last_step).transform(X)
 
-            return transform_array_to_frame(Xt, X)
+            Xt = transform_array_to_frame(Xt, X)
+            return transform_frame_to_series(Xt)
 
     @doc(SKPipeline._can_inverse_transform)
     def _can_inverse_transform(self):

--- a/test/transformer/test_pipeline.py
+++ b/test/transformer/test_pipeline.py
@@ -70,6 +70,15 @@ def test_pipeline_work(name, data, pipeline):
     joblib.dump(pipeline, f"{name}.pipeline.joblib")
 
 
+def test_series_input_and_series_output():
+    pipeline = make_pipeline(
+        MinMaxScaler(),
+    )
+    result = pipeline.fit_transform(s)
+
+    assert isinstance(result, pd.Series)
+
+
 def test_inverse_transform_type():
     pipeline = make_pipeline(
         GetTF(["target"]),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

`sklearn.preprocessing.MinMaxScaler` doesn't support Series.
`dtoolkit.transformer.make_pipeline(MinMaxScaler())` should support Series but actually not.