### PR TITLE
BUG: `OneHotEncoder`'s `fit_transform` use inputting's index

### DIFF
--- a/dtoolkit/transformer/sklearn.py
+++ b/dtoolkit/transformer/sklearn.py
@@ -104,6 +104,6 @@ class OneHotEncoder(SKOneHotEncoder):
                 else chain.from_iterable(self.categories_)
             )
 
-            return pd.DataFrame(Xt, columns=categories)
+            return pd.DataFrame(Xt, columns=categories, index=X.index)
 
         return Xt

--- a/test/transformer/test_sklearn.py
+++ b/test/transformer/test_sklearn.py
@@ -2,7 +2,6 @@ from test.transformer.conftest import df_label
 
 import pandas as pd
 from scipy import sparse
-from tkinter import ON
 
 from dtoolkit.transformer import OneHotEncoder
 

--- a/test/transformer/test_sklearn.py
+++ b/test/transformer/test_sklearn.py
@@ -1,3 +1,4 @@
+from tkinter import ON
 from test.transformer.conftest import df_label
 
 import pandas as pd
@@ -24,3 +25,12 @@ class TestOneHotEncoder:
         result = tf.fit_transform(df_label)
 
         assert sparse.isspmatrix(result)
+
+    def test_index(self):
+        from dtoolkit.transformer import make_pipeline
+
+        tf = make_pipeline(OneHotEncoder())
+        data = pd.DataFrame(["a", "b", "c"], index=[0, 1, 3])
+        result = tf.fit_transform(data)
+
+        assert result.index.equals(data.index)

--- a/test/transformer/test_sklearn.py
+++ b/test/transformer/test_sklearn.py
@@ -1,8 +1,8 @@
-from tkinter import ON
 from test.transformer.conftest import df_label
 
 import pandas as pd
 from scipy import sparse
+from tkinter import ON
 
 from dtoolkit.transformer import OneHotEncoder
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

If input a Series/DataFrame, `OneHotEncoder`'s `fit_transform` would return range index not the inputting's index.