### PR TITLE
TYP: add `Number` and `IntOrStr` annotation constants

### DIFF
--- a/dtoolkit/_typing.py
+++ b/dtoolkit/_typing.py
@@ -9,3 +9,5 @@ TwoDimArray = Union[np.ndarray, pd.DataFrame]
 OneDimArray = Union[np.ndarray, pd.Series]
 
 IntOrStr = Union[int, str]
+
+Number = Union[int, float]

--- a/dtoolkit/_typing.py
+++ b/dtoolkit/_typing.py
@@ -7,3 +7,5 @@ SeriesOrFrame = Union[pd.Series, pd.DataFrame]
 
 TwoDimArray = Union[np.ndarray, pd.DataFrame]
 OneDimArray = Union[np.ndarray, pd.Series]
+
+IntOrStr = Union[int, str]

--- a/dtoolkit/accessor/_util.py
+++ b/dtoolkit/accessor/_util.py
@@ -10,6 +10,7 @@ from dtoolkit.util import multi_if_else
 if TYPE_CHECKING:
     from typing import Iterable
 
+    from dtoolkit._typing import IntOrStr
     from dtoolkit._typing import OneDimArray
     from dtoolkit._typing import SeriesOrFrame
     from dtoolkit._typing import TwoDimArray
@@ -41,7 +42,7 @@ def get_mask(how: str, mask: TwoDimArray, axis: int) -> OneDimArray:
 def isin(
     df: pd.DataFrame,
     values: Iterable | SeriesOrFrame | dict[str, list[str]],
-    axis: int | str = 0,
+    axis: IntOrStr = 0,
 ) -> pd.DataFrame:
     """
     Extend :meth:`~pandas.DataFrame.isin` function. When ``values`` is

--- a/dtoolkit/accessor/dataframe.py
+++ b/dtoolkit/accessor/dataframe.py
@@ -18,6 +18,8 @@ from dtoolkit.accessor.series import top_n as s_top_n
 if TYPE_CHECKING:
     from typing import Iterable
 
+    from dtoolkit._typing import IntOrStr
+
 
 @register_dataframe_method
 @doc(
@@ -31,14 +33,14 @@ if TYPE_CHECKING:
     """,
     ),
 )
-def cols(df: pd.DataFrame) -> list[str | int]:
+def cols(df: pd.DataFrame) -> list[IntOrStr]:
     return df.columns.tolist()
 
 
 @register_dataframe_method
 def drop_inf(
     df: pd.DataFrame,
-    axis: int | str = 0,
+    axis: IntOrStr = 0,
     how: str = "any",
     inf: str = "all",
     subset: list[str] | None = None,
@@ -175,7 +177,7 @@ def drop_inf(
 def filter_in(
     df: pd.DataFrame,
     condition: Iterable | pd.Series | pd.DataFrame | dict[str, list[str]],
-    axis: int | str = 0,
+    axis: IntOrStr = 0,
     how: str = "all",
     inplace: bool = False,
 ) -> pd.DataFrame | None:
@@ -316,7 +318,7 @@ def filter_in(
 def repeat(
     df: pd.DataFrame,
     repeats: int | list[int],
-    axis: int | str = 0,
+    axis: IntOrStr = 0,
 ) -> pd.DataFrame | None:
     """
     Repeat row or column of a :obj:`~pandas.DataFrame`.
@@ -591,7 +593,7 @@ def top_n(
 )
 def expand(
     df: pd.DataFrame,
-    suffix: list[str | int] | None = None,
+    suffix: list[IntOrStr] | None = None,
     delimiter: str = "_",
     flatten: bool = False,
 ) -> pd.DataFrame:
@@ -609,7 +611,7 @@ def expand(
 
 
 @register_dataframe_method
-def to_series(df: pd.DataFrame, name: str | int = None) -> SeriesOrFrame:
+def to_series(df: pd.DataFrame, name: IntOrStr = None) -> SeriesOrFrame:
     """
     Transform one column :class:`~pandas.DataFrame` to :class:`~pandas.Series`.
 

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
     from dtoolkit._typing import IntOrStr
     from dtoolkit._typing import OneDimArray
+    from dtoolkit._typing import Number
 
 
 @register_series_method
@@ -450,7 +451,7 @@ def lens(s: pd.Series, number: int | None = 1, other: int | None = None) -> pd.S
 @register_series_method
 def error_report(
     s: pd.Series,
-    predicted: OneDimArray | list[int | float],
+    predicted: OneDimArray | list[Number],
     columns: list[IntOrStr] | None = None,
 ) -> pd.DataFrame:
     """

--- a/dtoolkit/accessor/series.py
+++ b/dtoolkit/accessor/series.py
@@ -12,6 +12,7 @@ from dtoolkit.accessor.register import register_series_method
 if TYPE_CHECKING:
     from typing import Any
 
+    from dtoolkit._typing import IntOrStr
     from dtoolkit._typing import OneDimArray
 
 
@@ -307,7 +308,7 @@ def top_n(
 )
 def expand(
     s: pd.Series,
-    suffix: list[str | int] | None = None,
+    suffix: list[IntOrStr] | None = None,
     delimiter: str = "_",
     flatten: bool = False,
 ) -> pd.DataFrame:
@@ -450,7 +451,7 @@ def lens(s: pd.Series, number: int | None = 1, other: int | None = None) -> pd.S
 def error_report(
     s: pd.Series,
     predicted: OneDimArray | list[int | float],
-    columns: list[str | int] | None = None,
+    columns: list[IntOrStr] | None = None,
 ) -> pd.DataFrame:
     """
     Calculate `absolute error` and `relative error` of two columns.

--- a/dtoolkit/geoaccessor/dataframe.py
+++ b/dtoolkit/geoaccessor/dataframe.py
@@ -11,6 +11,8 @@ from dtoolkit.accessor.register import register_dataframe_method
 if TYPE_CHECKING:
     from pyproj import CRS
 
+    from dtoolkit._typing import IntOrStr
+
 
 @register_dataframe_method
 def points_from_xy(
@@ -18,7 +20,7 @@ def points_from_xy(
     x: str,
     y: str,
     z: str | None = None,
-    crs: CRS | str | int | None = None,
+    crs: CRS | IntOrStr | None = None,
     drop: bool = False,
 ) -> gpd.GeoSeries | gpd.GeoDataFrame:
     """

--- a/dtoolkit/geoaccessor/geodataframe.py
+++ b/dtoolkit/geoaccessor/geodataframe.py
@@ -15,6 +15,7 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 if TYPE_CHECKING:
     from dtoolkit._typing import OneDimArray
+    from dtoolkit._typing import Number
 
 
 @register_geodataframe_method
@@ -56,7 +57,7 @@ if TYPE_CHECKING:
 )
 def geobuffer(
     df: gpd.GeoDataFrame,
-    distance: int | float | list[int | float] | OneDimArray,
+    distance: Number | list[Number] | OneDimArray,
     **kwargs,
 ) -> gpd.GeoDataFrame:
     return df.assign(geometry=df.geometry.geobuffer(distance, **kwargs))

--- a/dtoolkit/geoaccessor/geoseries.py
+++ b/dtoolkit/geoaccessor/geoseries.py
@@ -14,6 +14,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 if TYPE_CHECKING:
     from dtoolkit._typing import OneDimArray
+    from dtoolkit._typing import Number
 
 
 @register_geoseries_method
@@ -50,7 +51,7 @@ if TYPE_CHECKING:
 )
 def geobuffer(
     s: gpd.GeoSeries,
-    distance: int | float | list[int | float] | OneDimArray,
+    distance: Number | list[Number] | OneDimArray,
     **kwargs,
 ) -> gpd.GeoSeries:
     """

--- a/dtoolkit/transformer/factory.py
+++ b/dtoolkit/transformer/factory.py
@@ -8,6 +8,9 @@ from dtoolkit.util.generic import snake_to_camel
 if TYPE_CHECKING:
     from typing import Callable
 
+    from dtoolkit._typing import Number
+
+
 
 def methodtf_factory(
     transform_method: Callable,
@@ -37,13 +40,13 @@ def methodtf_factory(
         # Generate a plus/minus constant transformer:
 
 
-        def plus_constant(X: np.ndarray, constant: int | float) -> np.ndarray:
+        def plus_constant(X: np.ndarray, constant: Number) -> np.ndarray:
             '''Plus constant to each element of ``X``'''
 
             return X + constant
 
 
-        def minus_constant(X: np.ndarray, constant: int | float) -> np.ndarray:
+        def minus_constant(X: np.ndarray, constant: Number) -> np.ndarray:
             '''Minus constant to each element of ``X``'''
 
             return X - constant

--- a/dtoolkit/transformer/factory.py
+++ b/dtoolkit/transformer/factory.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from dtoolkit._typing import Number
 
 
-
 def methodtf_factory(
     transform_method: Callable,
     inverse_transform_method: Callable | None = None,

--- a/dtoolkit/transformer/factory.py
+++ b/dtoolkit/transformer/factory.py
@@ -8,8 +8,6 @@ from dtoolkit.util.generic import snake_to_camel
 if TYPE_CHECKING:
     from typing import Callable
 
-    from dtoolkit._typing import Number
-
 
 def methodtf_factory(
     transform_method: Callable,
@@ -39,13 +37,13 @@ def methodtf_factory(
         # Generate a plus/minus constant transformer:
 
 
-        def plus_constant(X: np.ndarray, constant: Number) -> np.ndarray:
+        def plus_constant(X: np.ndarray, constant: int | float) -> np.ndarray:
             '''Plus constant to each element of ``X``'''
 
             return X + constant
 
 
-        def minus_constant(X: np.ndarray, constant: Number) -> np.ndarray:
+        def minus_constant(X: np.ndarray, constant: int | float) -> np.ndarray:
             '''Minus constant to each element of ``X``'''
 
             return X - constant


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

- `Number` replace for `int` and `float`
- `IntOrStr` replace for `int` and `str`, it could be column/index or axis