### PR TITLE
EHN: Use `.loc[:, wrong_keys]` instead of `.get(wrong_keys)`

### DIFF
--- a/dtoolkit/accessor/dataframe.py
+++ b/dtoolkit/accessor/dataframe.py
@@ -702,7 +702,7 @@ def to_series(
 
         return (
             df.set_index(index_column)
-            .get(value_column)
+            .loc[:, value_column]
             .rename(
                 name or value_column,
             )

--- a/dtoolkit/accessor/dataframe.py
+++ b/dtoolkit/accessor/dataframe.py
@@ -602,7 +602,7 @@ def expand(
 ) -> pd.DataFrame:
     return pd.concat(
         (
-            df.get(key=column).expand(
+            df.get(column).expand(
                 suffix=suffix,
                 delimiter=delimiter,
                 flatten=flatten,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

The returned None would break the chain method.
Instead using `loc` would raise a error to notify user, keys are wrong.