### PR TITLE
EHN: New option `order` for `values_to_dict`

### DIFF
--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -45,7 +45,7 @@ def values_to_dict(
     ...     {
     ...         "x" : ["A", "A", "B", "B", "B"],
     ...         "y" : ["a", "b", "c", "d", "d"],
-    ...         "z" : [1, 2, 3, 3, 4],
+    ...         "z" : ["1", "2", "3", "3", "4"],
     ...     }
     ... )
     >>> df
@@ -63,19 +63,19 @@ def values_to_dict(
     {
         "A": {
             "a": [
-                1
+                "1"
             ],
             "b": [
-                2
+                "2"
             ]
         },
         "B": {
             "c": [
-                3
+                "3"
             ],
             "d": [
-                3,
-                4
+                "3",
+                "4"
             ]
         }
     }
@@ -116,16 +116,16 @@ def values_to_dict(
     >>> print(json.dumps(df.values_to_dict(order=["x", "z"]), indent=4))
     {
         "A": [
-            1,
-            2
+            "1",
+            "2"
         ],
         "B": [
-            3,
-            3,
-            4
+            "3",
+            "3",
+            "4"
         ]
     }
-    >>> print(json.dumps(df.values_to_dict(order=["z", "y", "x"]), indent=4))
+    >>> print(json.dumps(df.values_to_dict(order=["x", "z", "y"]), indent=4))
     {
         "A": {
             "1": [

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -7,7 +7,11 @@ from dtoolkit.accessor.series import values_to_dict as s_values_to_dict  # noqa
 
 
 @register_dataframe_method
-def values_to_dict(df: pd.DataFrame, few_as_key: bool = True) -> dict:
+def values_to_dict(
+    df: pd.DataFrame,
+    order: list | tuple = None,
+    few_as_key: bool = True,
+) -> dict:
     """
     Convert :attr:`~pandas.DataFrame.values` to :class:`dict`.
 
@@ -127,15 +131,14 @@ def values_to_dict(df: pd.DataFrame, few_as_key: bool = True) -> dict:
     if df.shape[1] == 1:  # one columns DataFrame
         return df.to_series().values_to_dict()
 
-    return _dict(
-        df.get(
-            df.unique_counts()
-            .sort_values(
-                ascending=few_as_key,
-            )
-            .index,
-        ),
+    columns = order or (
+        df.unique_counts()
+        .sort_values(
+            ascending=few_as_key,
+        )
+        .index
     )
+    return _dict(df[columns])
 
 
 def _dict(df: pd.DataFrame) -> dict:

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -110,7 +110,7 @@ def values_to_dict(
         }
     }
 
-    Output the arbitry order like ``{z: x}  or ``{x: {z: [y]} }``,
+    Output the arbitrary order like ``{z: x}  or ``{x: {z: [y]} }``,
     via ``order`` argument.
 
     >>> print(json.dumps(df.values_to_dict(order=["x", "z"]), indent=4))

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -17,6 +17,10 @@ def values_to_dict(
 
     Parameters
     ----------
+    order : list or tuple, optional
+        The order of keys via given columns. If ``order`` is set, ``few_as_key``
+        will not work.
+
     few_as_key : bool, default True
         If True the key would be the few unique of column values first.
 
@@ -76,7 +80,8 @@ def values_to_dict(
         }
     }
 
-    Use many unique of column values as key first.
+    Use many unique of column values as key first, the result will be
+    ``{y: {z: [x]} }``.
 
     >>> print(json.dumps(df.values_to_dict(few_as_key=False), indent=4))
     {
@@ -105,7 +110,43 @@ def values_to_dict(
         }
     }
 
-    Also could convert one column DataFrame. But ``few_as_key`` wouldn' work.
+    Output the arbitry order like ``{z: x}  or ``{x: {z: [y]} }``,
+    via ``order`` argument.
+
+    >>> print(json.dumps(df.values_to_dict(order=["x", "z"]), indent=4))
+    {
+        "A": [
+            1,
+            2
+        ],
+        "B": [
+            3,
+            3,
+            4
+        ]
+    }
+    >>> print(json.dumps(df.values_to_dict(order=["z", "y", "x"]), indent=4))
+    {
+        "A": {
+            "1": [
+                "a"
+            ],
+            "2": [
+                "b"
+            ]
+        },
+        "B": {
+            "3": [
+                "c",
+                "d"
+            ],
+            "4": [
+                "d"
+            ]
+        }
+    }
+
+    It also could convert one column DataFrame. But ``few_as_key`` wouldn' work.
     The result would be ``{index: [values]}``.
 
     >>> print(json.dumps(df[["x"]].values_to_dict(), indent=4))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Sometimes I want the order is not from few to many or reversed