### PR TITLE
EHN: new option `to_list` for `values_to_dict`

### DIFF
--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -11,6 +11,7 @@ def values_to_dict(
     df: pd.DataFrame,
     order: list | tuple = None,
     few_as_key: bool = True,
+    to_list: bool = True,
 ) -> dict:
     """
     Convert :attr:`~pandas.DataFrame.values` to :class:`dict`.
@@ -23,6 +24,9 @@ def values_to_dict(
 
     few_as_key : bool, default True
         If True the key would be the few unique of column values first.
+
+    to_list : bool, default True
+        If True one element value will return :keyword:`list`.
 
     Returns
     -------
@@ -167,10 +171,27 @@ def values_to_dict(
             "B"
         ]
     }
+
+    Unpack one element value list.
+
+    >>> print(json.dumps(df.values_to_dict(to_list=False), indent=4))
+    {
+        "A": {
+            "a": "1",
+            "b": "2"
+        },
+        "B": {
+            "c": "3",
+            "d": [
+                "3",
+                "4"
+            ]
+        }
+    }
     """
 
     if df.shape[1] == 1:  # one columns DataFrame
-        return df.to_series().values_to_dict()
+        return df.to_series().values_to_dict(to_list=to_list)
 
     columns = order or (
         df.unique_counts()
@@ -179,19 +200,22 @@ def values_to_dict(
         )
         .index
     )
-    return _dict(df[columns])
+    return _dict(df[columns], to_list=to_list)
 
 
-def _dict(df: pd.DataFrame) -> dict:
+def _dict(df: pd.DataFrame, to_list: bool) -> dict:
     key_column, *value_column = df.columns
 
     if df.shape[1] == 2:  # two column DataFrame
         return df.to_series(
             index_column=key_column,
             value_column=value_column[0],
-        ).values_to_dict()
+        ).values_to_dict(to_list=to_list)
 
     return {
-        key: _dict(df.loc[df[key_column] == key, value_column])
+        key: _dict(
+            df.loc[df[key_column] == key, value_column],
+            to_list=to_list,
+        )
         for key in df[key_column].unique()
     }

--- a/dtoolkit/accessor/series/values_to_dict.py
+++ b/dtoolkit/accessor/series/values_to_dict.py
@@ -12,7 +12,8 @@ if TYPE_CHECKING:
 
 @register_series_method
 def values_to_dict(
-    s: pd.Series, to_list: bool = True
+    s: pd.Series,
+    to_list: bool = True,
 ) -> dict[IntOrStr, list[IntOrStr] | IntOrStr]:
     """
     Convert :attr:`~pandas.Series.index` and :attr:`~pandas.Series.values` to

--- a/dtoolkit/accessor/series/values_to_dict.py
+++ b/dtoolkit/accessor/series/values_to_dict.py
@@ -85,10 +85,10 @@ def values_to_dict(
     }
 
 
-def unpack_list(l: list, to_list: bool = True) -> list[IntOrStr] | IntOrStr:
+def unpack_list(array: list, to_list: bool = True) -> list[IntOrStr] | IntOrStr:
     # unfold one element list
 
-    if not to_list and len(l) == 1:
-        return l[0]
+    if not to_list and len(array) == 1:
+        return array[0]
 
-    return l
+    return array

--- a/dtoolkit/accessor/series/values_to_dict.py
+++ b/dtoolkit/accessor/series/values_to_dict.py
@@ -11,10 +11,17 @@ if TYPE_CHECKING:
 
 
 @register_series_method
-def values_to_dict(s: pd.Series) -> dict[IntOrStr, list[IntOrStr]]:
+def values_to_dict(
+    s: pd.Series, to_list: bool = True
+) -> dict[IntOrStr, list[IntOrStr] | IntOrStr]:
     """
     Convert :attr:`~pandas.Series.index` and :attr:`~pandas.Series.values` to
     :class:`dict`.
+
+    Parameters
+    ----------
+    to_list : bool, default True
+        If True one element value will return :keyword:`list`.
 
     Returns
     -------
@@ -54,6 +61,33 @@ def values_to_dict(s: pd.Series) -> dict[IntOrStr, list[IntOrStr]]:
             3
         ]
     }
+
+    Unpack one element value list.
+
+    >>> print(json.dumps(s.values_to_dict(to_list=False), indent=4))
+    {
+        "a": [
+            0,
+            2
+        ],
+        "b": 1,
+        "c": 3
+    }
     """
 
-    return {key: s[s.index == key].to_list() for key in s.index.unique()}
+    return {
+        key: unpack_list(
+            s[s.index == key].to_list(),
+            to_list=to_list,
+        )
+        for key in s.index.unique()
+    }
+
+
+def unpack_list(l: list, to_list: bool = True) -> list[IntOrStr] | IntOrStr:
+    # unfold one element list
+
+    if not to_list and len(l) == 1:
+        return l[0]
+
+    return l


### PR DESCRIPTION
It could unfold one element value list

<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry
