### PR TITLE
PERF: Replace `.shape` with `.__len__`

### DIFF
--- a/dtoolkit/accessor/dataframe/to_series.py
+++ b/dtoolkit/accessor/dataframe/to_series.py
@@ -88,7 +88,7 @@ def to_series(
     Name: c, dtype: int64
     """
 
-    if df.shape[1] == 1:  # one column DataFrame
+    if df.columns.__len__() == 1:  # one column DataFrame
         column = df.columns[0]
         return df.get(column).rename(name or column)
 

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -199,7 +199,7 @@ def values_to_dict(
     }
     """
 
-    if df.shape[1] == 1:  # one columns DataFrame
+    if df.columns.__len__() == 1:  # one columns DataFrame
         return df.to_series().values_to_dict(to_list=to_list)
 
     columns = order or (
@@ -215,7 +215,7 @@ def values_to_dict(
 def _dict(df: pd.DataFrame, to_list: bool) -> dict:
     key_column, *value_column = df.columns
 
-    if df.shape[1] == 2:  # two column DataFrame
+    if df.columns.__len__() == 2:  # two column DataFrame
         return df.to_series(
             index_column=key_column,
             value_column=value_column[0],


### PR DESCRIPTION
```python
In [4]: timeit len(df.columns)
306 ns ± 5.61 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

In [5]: timeit df.shape[1]
800 ns ± 5.31 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry
