### PR TITLE
MAINT: Use `build` new distuils and add `pyproject.toml` configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@v3
 
       - name: Install Dependencies
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade build twine
 
       - name: Build sdist
         run: make dist

--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -44,12 +44,12 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v3
         with:
-          miniforge-variant: Mambaforge
           python-version: ${{ matrix.python-version }}
-          add-pip-as-python-dependency: true
-          use-mamba: true
+
+      - name: Install Dependencies
+        run: python -m pip install --upgrade build twine
 
       - name: Build sdist
         run: make dist

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ doctest:
 	pytest -v -r a -n auto --color=yes --cov=dtoolkit --cov-append --cov-report xml --doctest-only dtoolkit
 
 dist:
-	python setup.py sdist bdist_wheel
+	python -m build
+	twine check --strict dist/*
 	ls -l dist
 
 info:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,9 @@ doc =
     ipython
     ipykernel
     nbsphinx
-
+sdist =
+    build
+    twine
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
+import os
+import sys
+
 from setuptools import setup
 
-from versioneer import get_cmdclass
+# Ensure the current directory is on sys.path so versioneer can be imported
+# when pip uses PEP 517/518 build rules.
+# https://github.com/python-versioneer/python-versioneer/issues/193
+sys.path.append(os.path.dirname(__file__))
 
-setup(
-    cmdclass=get_cmdclass(),
-)
+from versioneer import get_cmdclass  # noqa: E402
+
+setup(cmdclass=get_cmdclass())


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Handle following message

```python
/usr/share/miniconda3/envs/test/lib/python3.7/site-packages/setuptools/command/install.py:37: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  setuptools.SetuptoolsDeprecationWarning
```
