### PR TITLE
DEP: Drop `inplace` option of `filter_in`

### DIFF
--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -22,8 +22,7 @@ def filter_in(
     condition: Iterable | pd.Series | pd.DataFrame | dict[str, list[str]],
     axis: IntOrStr = 0,
     how: str = "all",
-    inplace: bool = False,
-) -> pd.DataFrame | None:
+) -> pd.DataFrame:
     """
     Filter :obj:`~pandas.DataFrame` contents.
 
@@ -60,9 +59,6 @@ def filter_in(
 
         * 'any' : If any values are present, filter that row or column.
         * 'all' : If all values are present, filter that row or column.
-
-    inplace : bool, default is False
-        If True, do operation inplace and return None.
 
     Returns
     -------
@@ -137,9 +133,7 @@ def filter_in(
     falcon         2          2
     """
 
-    inplace = validate_bool_kwarg(inplace, "inplace")
     axis = df._get_axis_number(axis)
-
     another_axis = 1 - axis
 
     mask = isin(df, condition, axis)
@@ -149,8 +143,4 @@ def filter_in(
         mask = mask[names] if axis == 0 else mask.loc[names]
     mask = get_mask(how, mask, another_axis)
 
-    result = df.loc(axis=axis)[mask]
-    if not inplace:
-        return result
-
-    df._update_inplace(result)
+    return df.loc(axis=axis)[mask]

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from pandas.util._validators import validate_bool_kwarg
 
 from dtoolkit.accessor._util import get_mask
 from dtoolkit.accessor._util import isin

--- a/test/accessor/dataframe/test_filter_in.py
+++ b/test/accessor/dataframe/test_filter_in.py
@@ -14,14 +14,6 @@ def test_work():
     assert (~res["b"].isin([0, 1])).all()  # 0 and not in a
 
 
-def test_inplace_is_true():
-    df = d.copy(True)
-    res = df.filter_in({"a": [0, 1], "b": [2]}, inplace=True)
-
-    assert res is None
-    assert df.equals(d) is False
-
-
 def test_issue_145():
     # test my-data-toolkit#145
     df = pd.DataFrame(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Refer other `filter` methods. There don't have `inplace` option.