### PR TITLE
DEP: Drop `inplace` option of `filter_in`, warning message

### DIFF
--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -8,6 +8,7 @@ from pandas.util._validators import validate_bool_kwarg
 from dtoolkit.accessor._util import get_mask
 from dtoolkit.accessor._util import isin
 from dtoolkit.accessor.register import register_dataframe_method
+from dtoolkit.util._decorator import warning
 
 
 if TYPE_CHECKING:
@@ -17,6 +18,12 @@ if TYPE_CHECKING:
 
 
 @register_dataframe_method
+@warning(
+    "The 'inplace' option of 'dtoolkit.accessor.dataframe.filter_in' is deprecated "
+    "and will be removed in 0.0.16. (Warning added DToolKit 0.0.15)",
+    DeprecationWarning,
+    stacklevel=3,
+)
 def filter_in(
     df: pd.DataFrame,
     condition: Iterable | pd.Series | pd.DataFrame | dict[str, list[str]],
@@ -29,6 +36,10 @@ def filter_in(
 
     Similar to :meth:`~pandas.DataFrame.isin`, but the return is value not
     bool.
+
+    .. warning::
+        The ``inplace`` option of ``dtoolkit.accessor.dataframe.filter_in`` is
+        deprecated and will be removed in 0.0.16. (Warning added DToolKit 0.0.15)
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #518
- [ ] whatsnew entry
