### PR TITLE
EHN: Add `to_list` option for `cols`

### DIFF
--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -12,10 +12,16 @@ if TYPE_CHECKING:
 
 
 @register_dataframe_method
-def cols(df: pd.DataFrame) -> list[IntOrStr]:
+def cols(df: pd.DataFrame, to_list: bool = False) -> list[IntOrStr]:
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
+
+    Parameters
+    ----------
+    to_list : bool, default False
+        This option doesn't work, and it's used to fit
+        :method:`dtoolkit.accessor.series.cols` arguments.
 
     Returns
     -------

--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -48,7 +48,7 @@ def cols(df: pd.DataFrame, to_list: bool = False) -> list[IntOrStr]:
 
     Get :attr:`~pandas.DataFrame.columns`.
 
-    >>> d = pd.DataFrame({{"a": [1, 2], "b": [3, 4]}})
+    >>> d = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     >>> d.cols()
     ['a', 'b']
     """

--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from pandas.util._decorators import doc
 
 from dtoolkit.accessor.register import register_dataframe_method
-from dtoolkit.accessor.series import cols as s_cols
 
 
 if TYPE_CHECKING:
@@ -15,16 +12,39 @@ if TYPE_CHECKING:
 
 
 @register_dataframe_method
-@doc(
-    s_cols,
-    returns=dedent(
-        """
+def cols(df: pd.DataFrame) -> list[IntOrStr]:
+    """
+    An API to gather :attr:`~pandas.Series.name` and
+    :attr:`~pandas.DataFrame.columns` to one.
+
     Returns
     -------
     list of str or int
         The column names.
-    """,
-    ),
-)
-def cols(df: pd.DataFrame) -> list[IntOrStr]:
+
+    See Also
+    --------
+    pandas.Series.name
+    pandas.DataFrame.columns
+    dtoolkit.accessor.series.cols
+    dtoolkit.accessor.dataframe.cols
+
+    Examples
+    --------
+    >>> import dtoolkit.accessor
+    >>> import pandas as pd
+
+    Get :attr:`~pandas.Series.name`.
+
+    >>> s = pd.Series(range(10), name="item")
+    >>> s.cols()
+    'item'
+
+    Get :attr:`~pandas.DataFrame.columns`.
+
+    >>> d = pd.DataFrame({{"a": [1, 2], "b": [3, 4]}})
+    >>> d.cols()
+    ['a', 'b']
+    """
+
     return df.columns.tolist()

--- a/dtoolkit/accessor/series/cols.py
+++ b/dtoolkit/accessor/series/cols.py
@@ -48,12 +48,11 @@ def cols(
     >>> s.cols()
     'item'
     >>> s.cols(to_list=True)
-    >>>
     ['item']
 
     Get :attr:`~pandas.DataFrame.columns`.
 
-    >>> d = pd.DataFrame({{"a": [1, 2], "b": [3, 4]}})
+    >>> d = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     >>> d.cols()
     ['a', 'b']
     """

--- a/dtoolkit/accessor/series/cols.py
+++ b/dtoolkit/accessor/series/cols.py
@@ -1,29 +1,35 @@
 from __future__ import annotations
 
-from textwrap import dedent
+from typing import TYPE_CHECKING
 
 import pandas as pd
-from pandas.util._decorators import doc
 
 from dtoolkit.accessor.register import register_series_method
 
 
+if TYPE_CHECKING:
+    from dtoolkit._typing import IntOrStr
+
+
 @register_series_method
-@doc(
-    returns=dedent(
-        """
-    Returns
-    -------
-    str or None
-        The name of the Series.
-    """,
-    ),
-)
-def cols(s: pd.Series) -> str | None:
+def cols(
+    s: pd.Series,
+    to_list: bool = False,
+) -> IntOrStr | None | list[IntOrStr | None]:
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.
-    {returns}
+
+    Parameters
+    ----------
+    to_list : bool, default False
+        If True, return a list type.
+
+    Returns
+    -------
+    str, int, None or list of them
+        The name of the Series.
+
     See Also
     --------
     pandas.Series.name
@@ -41,6 +47,9 @@ def cols(s: pd.Series) -> str | None:
     >>> s = pd.Series(range(10), name="item")
     >>> s.cols()
     'item'
+    >>> s.cols(to_list=True)
+    >>>
+    ['item']
 
     Get :attr:`~pandas.DataFrame.columns`.
 
@@ -49,4 +58,4 @@ def cols(s: pd.Series) -> str | None:
     ['a', 'b']
     """
 
-    return s.name
+    return [s.name] if to_list else s.name

--- a/dtoolkit/transformer/sklearn.py
+++ b/dtoolkit/transformer/sklearn.py
@@ -99,7 +99,7 @@ class OneHotEncoder(SKOneHotEncoder):
 
         if self.sparse is False and isinstance(X, (pd.Series, pd.DataFrame)):
             categories = (
-                self.get_feature_names_out(X.cols())
+                self.get_feature_names_out(X.cols(to_list=True))
                 if self.categories_with_parent
                 else chain.from_iterable(self.categories_)
             )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Let `cols` could return list type especially for `Series.cols` method.