### PR TITLE
DEP: Drop `inplace` for `drop_inf`, no more `inplace`

### DIFF
--- a/dtoolkit/accessor/dataframe/drop_inf.py
+++ b/dtoolkit/accessor/dataframe/drop_inf.py
@@ -9,6 +9,7 @@ from pandas.util._validators import validate_bool_kwarg
 from dtoolkit.accessor._util import get_inf_range
 from dtoolkit.accessor.dataframe import boolean  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
+from dtoolkit.util._decorator import deprecated_kwargs
 
 
 if TYPE_CHECKING:
@@ -16,6 +17,13 @@ if TYPE_CHECKING:
 
 
 @register_dataframe_method
+@deprecated_kwargs(
+    "inplace",
+    message=(
+        "The keyword argument '{argument}' of '{func_name}' is deprecated and will "
+        "be removed in 0.0.17. (Warning added DToolKit 0.0.16)"
+    ),
+)
 def drop_inf(
     df: pd.DataFrame,
     axis: IntOrStr = 0,

--- a/dtoolkit/accessor/series/drop_inf.py
+++ b/dtoolkit/accessor/series/drop_inf.py
@@ -5,9 +5,17 @@ from pandas.util._validators import validate_bool_kwarg
 
 from dtoolkit.accessor._util import get_inf_range
 from dtoolkit.accessor.register import register_series_method
+from dtoolkit.util._decorator import deprecated_kwargs
 
 
 @register_series_method
+@deprecated_kwargs(
+    "inplace",
+    message=(
+        "The keyword argument '{argument}' of '{func_name}' is deprecated and will "
+        "be removed in 0.0.17. (Warning added DToolKit 0.0.16)"
+    ),
+)
 def drop_inf(
     s: pd.Series,
     inf: str = "all",


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #531
- [x] whatsnew entry

No more `inplace` option.