### PR TITLE
EHN: `how` only works on `condition` `DataFrame`'s columns

### DIFF
--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -37,10 +37,6 @@ def filter_in(
         * If ``condition`` is a :obj:`~pandas.DataFrame`, then both the index
           and column labels must be matched.
 
-        .. deprecated:: 0.0.15
-            The ``axis`` is deprecated and will be removed in 0.0.16. If want to
-            filter columns please use ``.T`` firstly. (Warning added DToolKit 0.0.15)
-
     how : {'any', 'all'}, default 'all'
         Determine whether the row is filtered from :obj:`~pandas.DataFrame`,
         when there have at least one value or all value.

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -52,6 +52,7 @@ def filter_in(
     --------
     pandas.DataFrame.isin
         Whether each element in the DataFrame is contained in values.
+
     pandas.DataFrame.filter
         Subset the dataframe rows or columns according to the specified index
         labels.

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -146,5 +146,8 @@ def select_column(
     if isinstance(condition, dict):
         # 'how' only works on condition these dictionary's keys
         return df[condition.keys()]
+    elif isinstance(condition, pd.DataFrame):
+        # 'how' only works on condition these DataFrame's columns
+        return df[condition.columns]
 
     return df

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -124,11 +124,11 @@ def filter_in(
     """
 
     return df[
-        df.isin(condition)
-        .pipe(
+        df.pipe(
             select_column,
             condition=condition,
         )
+        .isin(condition)
         .boolean(
             how=how,
             axis=1,

--- a/test/accessor/dataframe/test_filter_in.py
+++ b/test/accessor/dataframe/test_filter_in.py
@@ -137,6 +137,17 @@ df = pd.DataFrame(
                 index=["dog"],
             ),
         ),
+        (
+            pd.DataFrame({"legs": [2, 4, 2]}, index=["falcon", "dog", "cat"]),
+            dict(how="all", complement=False),
+            pd.DataFrame(
+                {
+                    "legs": [2, 4, 2],
+                    "wings": [2, 0, 0],
+                },
+                index=["falcon", "dog", "cat"],
+            ),
+        ),
     ],
 )
 def test_work(condition, kwargs, excepted):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

When condition is DataFrame, how option should only work on those selected columns.