### PR TITLE
DEP: Add deprecated warning for dtoolkit.transformer.pipeline

### DIFF
--- a/doc/source/reference/transformer.rst
+++ b/doc/source/reference/transformer.rst
@@ -21,6 +21,11 @@ Base transformer class for all transformers.
 
 Pipeline
 -------------------
+
+.. deprecated:: 0.0.17
+    The :mod:`dtoolkit.transformer.pipeline` package will be moved into
+    :mod:`dtoolkit.pipeline`` in 0.0.17. (Warning added DToolKit 0.0.16)
+
 .. autosummary::
     :toctree: api/
 

--- a/doc/source/reference/transformer.rst
+++ b/doc/source/reference/transformer.rst
@@ -24,7 +24,7 @@ Pipeline
 
 .. deprecated:: 0.0.17
     The :mod:`dtoolkit.transformer.pipeline` package will be moved into
-    :mod:`dtoolkit.pipeline`` in 0.0.17. (Warning added DToolKit 0.0.16)
+    :mod:`dtoolkit.pipeline` in 0.0.17. (Warning added DToolKit 0.0.16)
 
 .. autosummary::
     :toctree: api/

--- a/dtoolkit/transformer/pipeline/__init__.py
+++ b/dtoolkit/transformer/pipeline/__init__.py
@@ -1,4 +1,14 @@
+from warnings import warn
+
 from dtoolkit.transformer.pipeline.FeatureUnion import FeatureUnion  # noqa
 from dtoolkit.transformer.pipeline.make_pipeline import make_pipeline  # noqa
 from dtoolkit.transformer.pipeline.make_union import make_union  # noqa
 from dtoolkit.transformer.pipeline.Pipeline import Pipeline  # noqa
+from dtoolkit.util._exception import find_stack_level
+
+warn(
+    "The 'dtoolkit.transformer.pipeline' package will be moved into "
+    "'dtoolkit.pipeline' in 0.0.17. (Warning added DToolKit 0.0.16)",
+    FutureWarning,
+    find_stack_level(),
+)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Ready to move dtoolkit.transformer.pipeline to dtoolkit.pipeline