### PR TITLE
MAINT: Remove `TYPE_CHECKING` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ API changes:
 
 Maintenance development:
 
+- Remove `TYPE_CHECKING` blocks ({pr}`566`).
 - Simplify {meth}`~dtoolkit.accessor.register_method_factory` ({pr}`552`).
 - Correct name `excepted` -> `expected` ({pr}`547`).
 - Complete the accessor subpackage test suitcase ({pr}`544`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 New features and improvements:
 
-- New accessor {meth}`~dtoolkit.accessor.dataframe.fillna_regresssion` ({pr}`556`).
+- New accessor {meth}`~dtoolkit.accessor.dataframe.fillna_regression` ({pr}`556`).
 - New `unique` option for {meth}`~dtoolkit.accessor.dataframe.values_to_dict` ({pr}`548`).
-- Speed up `find_stack_level` ({pr}`546`).
+- Speed up {meth}`~dtoolkit.util._exception.find_stack_level` ({pr}`546`).
 - {meth}`~dtoolkit.accessor.dataframe.filter_in`'s `how` only works on `condition` `DataFrame`'s columns ({pr}`545`).
 - {meth}`~dtoolkit.accessor.series.to_set` speeds up especial to large data ({pr}`542`, {pr}`543`).
 - {meth}`~dtoolkit.accessor.dataframe.drop_inf`'s `inf` option supports `+` and `-` ({pr}`539`).
@@ -25,12 +25,12 @@ API changes:
 
 Maintenance development:
 
-- Simplify {meth}`dtoolkit.accessor.register_method_factory` ({pr}`552`).
+- Simplify {meth}`~dtoolkit.accessor.register_method_factory` ({pr}`552`).
 - Correct name `excepted` -> `expected` ({pr}`547`).
 - Complete the accessor subpackage test suitcase ({pr}`544`).
 - Move `collapse` from `_util` into `expand` ({pr}`541`).
 - Lint importing ({pr}`536`).
-- Test `deprecated_kwargs` ({pr}`534`).
+- Test {meth}`~dtoolkit.util._decorator.deprecated_kwargs` ({pr}`534`).
 - Index `._decorator` and `_exception` method ({pr}`532`).
 
 ## [Version 0.0.15] (2022-5-13)
@@ -39,7 +39,7 @@ New features and improvements:
 
 - New decorator {meth}`deprecated_kwargs` ({pr}`525`).
 - Add `to_list` option for {meth}`~dtoolkit.accessor.series.cols` ({pr}`523`).
-- Add the index register method {meth}`~dtoolkit.accessor.register_index_method`, support register method into {class}`pandas.Index` ({pr}`507`).
+- Add the index register method {meth}`~dtoolkit.accessor.register_index_method`, support register method into {class}`~pandas.Index` ({pr}`507`).
 
 API changes:
 

--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.register import register_dataframe_method
-
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/dataframe/decompose.py
+++ b/dtoolkit/accessor/dataframe/decompose.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 
 if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
     from sklearn.base import TransformerMixin
 
 

--- a/dtoolkit/accessor/dataframe/drop_inf.py
+++ b/dtoolkit/accessor/dataframe/drop_inf.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pandas as pd
 from pandas.util._validators import validate_bool_kwarg
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.dataframe import boolean  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.accessor.series.drop_inf import get_inf_range
 from dtoolkit.util._decorator import deprecated_kwargs
-
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/dataframe/expand.py
+++ b/dtoolkit/accessor/dataframe/expand.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING
 
 import pandas as pd
 from pandas.util._decorators import doc
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.accessor.series import expand as s_expand
-
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -1,18 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Iterable
 
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
+from dtoolkit._typing import SeriesOrFrame
 from dtoolkit.accessor.dataframe import boolean  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
-
-
-if TYPE_CHECKING:
-    from typing import Iterable
-
-    from dtoolkit._typing import IntOrStr
-    from dtoolkit._typing import SeriesOrFrame
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/dataframe/repeat.py
+++ b/dtoolkit/accessor/dataframe/repeat.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.register import register_dataframe_method
-
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/dataframe/repeat.py
+++ b/dtoolkit/accessor/dataframe/repeat.py
@@ -12,7 +12,7 @@ def repeat(
     df: pd.DataFrame,
     repeats: int | list[int],
     axis: IntOrStr = 0,
-) -> pd.DataFrame | None:
+) -> pd.DataFrame:
     """
     Repeat row or column of a :obj:`~pandas.DataFrame`.
 

--- a/dtoolkit/accessor/dataframe/to_series.py
+++ b/dtoolkit/accessor/dataframe/to_series.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit._typing import SeriesOrFrame
 from dtoolkit.accessor.register import register_dataframe_method
-
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.accessor.series import values_to_dict as s_values_to_dict  # noqa
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import Callable
 
 from pandas.api.extensions import register_dataframe_accessor
 from pandas.api.extensions import register_index_accessor
 from pandas.api.extensions import register_series_accessor
 from pandas.util._decorators import doc
 
-if TYPE_CHECKING:
-    from typing import Callable
-
-    from dtoolkit._typing import SeriesOrFrame
+from dtoolkit._typing import SeriesOrFrame
 
 
 def register_method_factory(register_accessor):

--- a/dtoolkit/accessor/series/cols.py
+++ b/dtoolkit/accessor/series/cols.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.register import register_series_method
-
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
 
 
 @register_series_method

--- a/dtoolkit/accessor/series/error_report.py
+++ b/dtoolkit/accessor/series/error_report.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
+from dtoolkit._typing import Number
+from dtoolkit._typing import OneDimArray
 from dtoolkit.accessor.register import register_series_method
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import IntOrStr
-    from dtoolkit._typing import OneDimArray
-    from dtoolkit._typing import Number
 
 
 @register_series_method

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING
+from typing import Iterable
 
 import pandas as pd
 from pandas.api.types import is_list_like
 from pandas.util._decorators import doc
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.register import register_series_method
-
-if TYPE_CHECKING:
-    from typing import Iterable
-
-    from dtoolkit._typing import IntOrStr
 
 
 @register_series_method

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -5,14 +5,13 @@ from typing import TYPE_CHECKING
 import geopandas as gpd
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 
 if TYPE_CHECKING:
     from pyproj import CRS
-
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method()

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -5,14 +5,13 @@ from typing import TYPE_CHECKING
 import geopandas as gpd
 import pandas as pd
 
+from dtoolkit._typing import IntOrStr
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 
 if TYPE_CHECKING:
     from pyproj import CRS
-
-    from dtoolkit._typing import IntOrStr
 
 
 @register_dataframe_method("points_from_xy")

--- a/dtoolkit/geoaccessor/geodataframe/geobuffer.py
+++ b/dtoolkit/geoaccessor/geodataframe/geobuffer.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING
 
 import geopandas as gpd
 from pandas.util._decorators import doc
 
+from dtoolkit._typing import Number
+from dtoolkit._typing import OneDimArray
 from dtoolkit.geoaccessor.geoseries import geobuffer as s_geobuffer
 from dtoolkit.geoaccessor.register import register_geodataframe_method
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import OneDimArray
-    from dtoolkit._typing import Number
 
 
 @register_geodataframe_method

--- a/dtoolkit/geoaccessor/geoseries/geobuffer.py
+++ b/dtoolkit/geoaccessor/geoseries/geobuffer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING
 
 import geopandas as gpd
 import numpy as np
@@ -10,12 +9,10 @@ from pandas.api.types import is_list_like
 from pandas.api.types import is_number
 from pandas.util._decorators import doc
 
+from dtoolkit._typing import Number
+from dtoolkit._typing import OneDimArray
 from dtoolkit.accessor.series import getattr  # noqa
 from dtoolkit.geoaccessor.register import register_geoseries_method
-
-if TYPE_CHECKING:
-    from dtoolkit._typing import OneDimArray
-    from dtoolkit._typing import Number
 
 
 @register_geoseries_method


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [X] whatsnew entry

Remove most type-checking blocks, only keep these maybe 'cause importing error