### PR TITLE
CI: Don't skip dist when `ci/**` path files changing

### DIFF
--- a/.github/workflows/sdist.yml
+++ b/.github/workflows/sdist.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: fkirc/skip-duplicate-actions@v4.0.0
         id: skip-check
         with:
-          paths_ignore: '["doc/**", "ci/**", "test/**"]'
+          paths_ignore: '["doc/**", "test/**"]'
           do_not_skip: '["push"]'
 
   sdist:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Documentation:
 
 Maintenance development:
 
+- Don't skip dist when `ci/**` path files changing ({pr}`570`).
 - Remove `TYPE_CHECKING` blocks ({pr}`566`).
 - Remove `__future__` useless line importing ({pr}`564`).
 - Simplify {meth}`~dtoolkit.accessor.register_method_factory` ({pr}`552`).


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

When CI config changes, it will affect the steps of the dist.