### PR TITLE
BUG: hook method's attrs into both class and instance

### DIFF
--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -34,6 +34,7 @@ def register_method_factory(register_accessor):
 
     # based on pandas_flavor/register.py
     def register_accessor_method(method: Callable, name: str):
+        @wraps(method)
         def method_accessor(pd_obj: SeriesOrFrame):
             @wraps(method)
             def wrapper(*args, **kwargs):

--- a/test/accessor/test_register.py
+++ b/test/accessor/test_register.py
@@ -120,6 +120,7 @@ def test_work(data, name, expected):
 @pytest.mark.parametrize(
     "data, name, attr, expected",
     [
+        # test instance
         (df, "name_or_columns", "__name__", name_or_columns.__name__),
         (df.a, "name_or_columns", "__name__", name_or_columns.__name__),
         (df.index, "name_or_columns", "__name__", name_or_columns.__name__),
@@ -138,6 +139,11 @@ def test_work(data, name, expected):
         (df, "alias_name_or_columns_1", "__doc__", name_or_columns_2.__doc__),
         (df.a, "alias_name_or_columns_1", "__doc__", name_or_columns_2.__doc__),
         (df.index, "alias_name_or_columns_1", "__doc__", name_or_columns_2.__doc__),
+        # test class
+        (pd.DataFrame, "name_or_columns", "__name__", name_or_columns.__name__),
+        (pd.DataFrame, "name_or_columns_1", "__doc__", name_or_columns_1.__doc__),
+        (pd.DataFrame, "alias_name_or_columns", "__name__", name_or_columns_2.__name__),
+        (pd.DataFrame, "alias_name_or_columns_1", "__doc__", name_or_columns_2.__doc__),
     ],
 )
 def test_method_hooked_attr(data, name, attr, expected):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #552
- [x] whatsnew entry

class doesn't have this hooked accessor method's attributes.

```python
import dtoolkit.accessor

import pandas as pd

df = pd.DataFrame()
print(pd.DataFrame.cols)
print(pd.DataFrame.cols.__name__)
print(df.cols.__name__)
print(df.cols)

# before
# <function register_method_factory.<locals>.register_accessor_method.<locals>.method_accessor at 0x000001FF08D96790>
# method_accessor
# cols
# <function cols at 0x000001FF063DF0D0>

# now
# <function cols at 0x000002D61C0565E0>
# cols
# cols
# <function cols at 0x000002D617B7F0D0>
```