### PR TITLE
BUG: `geobuffer` uses the default geometry to generate buffers

### DIFF
--- a/dtoolkit/geoaccessor/geodataframe/geobuffer.py
+++ b/dtoolkit/geoaccessor/geodataframe/geobuffer.py
@@ -55,8 +55,10 @@ def geobuffer(
 ) -> gpd.GeoDataFrame:
 
     return df.assign(
-        geometry=df.geometry.geobuffer(
-            distance,
-            **kwargs,
-        ),
+        **{
+            df.geometry.name: df.geometry.geobuffer(
+                distance,
+                **kwargs,
+            ),
+        },
     )

--- a/test/geoaccessor/geodataframe/test_geobuffer.py
+++ b/test/geoaccessor/geodataframe/test_geobuffer.py
@@ -39,3 +39,14 @@ def test_distance_index_is_different_to_data():
 def test_distance_length_is_different_to_data():
     with pytest.raises(IndexError):
         df.geobuffer([1, 1000])
+
+
+def test_renamed_geometry():
+    default_geometry_column_name = "geometry"
+    new_geometry_column_name = "geom"
+
+    df_renamed = df.rename_geometry(new_geometry_column_name)
+    result = df_renamed.geobuffer(10)
+
+    assert new_geometry_column_name in result.columns
+    assert default_geometry_column_name not in result.columns

--- a/test/geoaccessor/geodataframe/test_geobuffer.py
+++ b/test/geoaccessor/geodataframe/test_geobuffer.py
@@ -30,11 +30,6 @@ def test_distance_work(distance):
     assert isinstance(b, gpd.GeoDataFrame)
 
 
-def test_distance_is_pd_series():
-    df_distance = pd.Series(range(1, 1000, 499))
-    df.geobuffer(df_distance)
-
-
 def test_distance_index_is_different_to_data():
     df_distance = pd.Series(range(1, 1000, 499), index=["a", "b", "c"])
     with pytest.raises(IndexError):

--- a/test/geoaccessor/geodataframe/test_geobuffer.py
+++ b/test/geoaccessor/geodataframe/test_geobuffer.py
@@ -26,6 +26,7 @@ crs = CRS.from_user_input("epsg:4326")
 )
 def test_distance_work(distance):
     b = df.geobuffer(distance)
+
     assert isinstance(b, gpd.GeoDataFrame)
 
 

--- a/test/geoaccessor/geoseries/test_geobuffer.py
+++ b/test/geoaccessor/geoseries/test_geobuffer.py
@@ -32,11 +32,6 @@ def test_distance_work(distance):
     assert isinstance(b, gpd.GeoSeries)
 
 
-def test_distance_is_pd_series():
-    df_distance = pd.Series(range(1, 1000, 499))
-    s.geobuffer(df_distance)
-
-
 def test_distance_index_is_different_to_data():
     df_distance = pd.Series(range(1, 1000, 499), index=["a", "b", "c"])
     with pytest.raises(IndexError):

--- a/test/geoaccessor/geoseries/test_geobuffer.py
+++ b/test/geoaccessor/geoseries/test_geobuffer.py
@@ -28,6 +28,7 @@ s = gpd.GeoSeries.from_wkt(
 )
 def test_distance_work(distance):
     b = s.geobuffer(distance)
+
     assert isinstance(b, gpd.GeoSeries)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

```python
import dtoolkit.geoaccessor
import pandas as pd

df = pd.DataFrame({"x": [122, 100], "y": [55, 1]})
gdf = df.from_xy("x", "y", crs="EPSG:4326")
print(gdf.geometry.name)
# geometry

gdf_rename_geometry = gdf.rename_geometry("geom")
print(gdf_rename_geometry.geometry.name)
# geom

print(gdf_rename_geometry.geobuffer(10))
# before: two geometry are these
#      x   y                        geom                                           geometry
# 0  122  55  POINT (122.00000 55.00000)  POLYGON ((122.00016 55.00000, 122.00016 54.999...
# 1  100   1   POINT (100.00000 1.00000)  POLYGON ((100.00009 1.00000, 100.00009 0.99999...

# now: only one geometry
#      x   y                                               geom
# 0  122  55  POLYGON ((122.00016 55.00000, 122.00016 54.999...
# 1  100   1  POLYGON ((100.00009 1.00000, 100.00009 0.99999...
```