### PR TITLE
PREF: Speed up `to_set`

### DIFF
--- a/dtoolkit/accessor/index/to_set.py
+++ b/dtoolkit/accessor/index/to_set.py
@@ -21,6 +21,7 @@ def to_set(index: pd.Index) -> set:
     See Also
     --------
     pandas.Index.unique
+    dtoolkit.accessor.series.to_set
 
     Examples
     --------

--- a/dtoolkit/accessor/index/to_set.py
+++ b/dtoolkit/accessor/index/to_set.py
@@ -33,4 +33,4 @@ def to_set(index: pd.Index) -> set:
     {1, 2}
     """
 
-    return set(index.unique())
+    return set(index.to_list())

--- a/dtoolkit/accessor/index/to_set.py
+++ b/dtoolkit/accessor/index/to_set.py
@@ -34,4 +34,4 @@ def to_set(index: pd.Index) -> set:
     {1, 2}
     """
 
-    return set(index.to_list())
+    return set(index.unique())

--- a/dtoolkit/accessor/series/to_set.py
+++ b/dtoolkit/accessor/series/to_set.py
@@ -36,4 +36,4 @@ def to_set(s: pd.Series) -> set:
     {1, 2}
     """
 
-    return set(s.unique())
+    return set(s.to_list())

--- a/dtoolkit/accessor/series/to_set.py
+++ b/dtoolkit/accessor/series/to_set.py
@@ -21,6 +21,7 @@ def to_set(s: pd.Series) -> set:
     See Also
     --------
     pandas.Series.unique
+    dtoolkit.accessor.index.to_set
 
     Examples
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #543
- [x] whatsnew entry

test via `timeit command`

|              `s = `              | loop ranges |     `set(s)`      | `set(s.values)`  | `set(s.to_numpy())` | `set(s.to_list())` | `set(s.unique())` |
| :------------------------------: | :---------: | :---------------: | :--------------: | :-----------------: | :----------------: | :---------------: |
|      `pd.Series(range(10))`      |  7e4 ~ 7e6  | 2.36 µs ± 70.2 ns | 2.42 µs ± 123 ns |  3.45 µs ± 82.7 ns  |  999 ns ± 18.2 ns  | 27.4 µs ± 771 ns  |
| `pd.Series(list(range(10))*1e4)` |  7e2 ~ 7e3  | 8.33 ms ± 665 µs  | 6.46 ms ± 198 µs |  6.75 ms ± 500 µs   | 1.75 ms ± 23.7 µs  | 952 µs ± 8.71 µs  |
|   `pd.Series(range(int(1e5)))`   |     7e2     | 13.7 ms ± 469 µs  | 9.95 ms ± 472 µs |  9.77 ms ± 649 µs   |  6.3 ms ± 328 µs   | 12.7 ms ± 820 µs  |
