### PR TITLE
MAINT: `(Geo)DataFrame` methods don't return `(Geo)Series` anymore

### DIFF
--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -50,8 +50,10 @@ def from_wkb(
 
     Returns
     -------
-    GeoSeries or GeoDataFrame
-        GeoSeries if dropped ``df`` is empty else GeoDataFrame.
+    GeoDataFrame
+        .. deprecated:: 0.0.17
+            The result doesn't support returning 'GeoSeries' anymore, even one column
+            'GeoDataFrame'. (Warning added DToolKit 0.0.17)
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -53,7 +53,7 @@ def from_wkb(
     GeoDataFrame
         .. deprecated:: 0.0.17
             The result doesn't support returning 'GeoSeries' anymore, even one column
-            'GeoDataFrame'. (Warning added DToolKit 0.0.17)
+            'GeoDataFrame'.
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -103,14 +103,14 @@ def from_wkb(
 
     Drop original 'wkb' column.
 
-    >>> gs = s_wkb.to_frame("wkb").from_wkb("wkb", crs=4326, drop=True)
-    >>> gs
-    0    POINT (1.00000 1.00000)
-    1    POINT (2.00000 2.00000)
-    2    POINT (3.00000 3.00000)
-    Name: geometry, dtype: geometry
-    >>> type(gs)
-    <class 'geopandas.geoseries.GeoSeries'>
+    >>> gdf = s_wkb.to_frame("wkb").from_wkb("wkb", crs=4326, drop=True)
+    >>> gdf
+                      geometry
+    0  POINT (1.00000 1.00000)
+    1  POINT (2.00000 2.00000)
+    2  POINT (3.00000 3.00000)
+    >>> type(gdf)
+    <class 'geopandas.geoseries.GeoDataFrame'>
     """
 
     return gpd.GeoDataFrame(

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -109,7 +109,7 @@ def from_wkb(
     1  POINT (2.00000 2.00000)
     2  POINT (3.00000 3.00000)
     >>> type(gdf)
-    <class 'geopandas.geoseries.GeoDataFrame'>
+    <class 'geopandas.geodataframe.GeoDataFrame'>
     """
 
     return gpd.GeoDataFrame(

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -8,20 +8,12 @@ import pandas as pd
 
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
-from dtoolkit.util._decorator import warning
 
 if TYPE_CHECKING:
     from pyproj import CRS
 
 
 @register_dataframe_method
-@warning(
-    (
-        "The result doesn't support returning 'GeoSeries' anymore, "
-        "even one column 'GeoDataFrame'. (Warning added DToolKit 0.0.17)"
-    ),
-    stacklevel=3,
-)
 def from_wkb(
     df: pd.DataFrame,
     column: Hashable,
@@ -50,9 +42,6 @@ def from_wkb(
     Returns
     -------
     GeoDataFrame
-        .. deprecated:: 0.0.17
-            The result doesn't support returning 'GeoSeries' anymore, even one column
-            'GeoDataFrame'.
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -9,18 +9,26 @@ import pandas as pd
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
+from dtoolkit.util._decorator import warning
 
 if TYPE_CHECKING:
     from pyproj import CRS
 
 
 @register_dataframe_method
+@warning(
+    (
+        "The result doesn't support returning 'GeoSeries' anymore, "
+        "even one column 'GeoDataFrame'. (Warning added DToolKit 0.0.17)"
+    ),
+    stacklevel=3,
+)
 def from_wkb(
     df: pd.DataFrame,
     column: Hashable,
     crs: CRS | str | int = None,
     drop: bool = False,
-) -> gpd.GeoSeries | gpd.GeoDataFrame:
+) -> gpd.GeoDataFrame:
     """
     Generate :obj:`~geopandas.GeoDataFrame` of geometries from 'WKB' column of
     :obj:`~pandas.DataFrame`.
@@ -107,4 +115,4 @@ def from_wkb(
         df.drop_or_not(drop=drop, columns=column),
         geometry=gpd.GeoSeries.from_wkb(df[column]),
         crs=crs,
-    ).to_series()
+    )

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -7,7 +7,6 @@ import geopandas as gpd
 import pandas as pd
 
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
-from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.util._decorator import warning
 

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -9,18 +9,26 @@ import pandas as pd
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
+from dtoolkit.util._decorator import warning
 
 if TYPE_CHECKING:
     from pyproj import CRS
 
 
 @register_dataframe_method
+@warning(
+    (
+        "The result doesn't support returning 'GeoSeries' anymore, "
+        "even one column 'GeoDataFrame'. (Warning added DToolKit 0.0.17)"
+    ),
+    stacklevel=3,
+)
 def from_wkt(
     df: pd.DataFrame,
     column: Hashable,
     crs: CRS | str | int = None,
     drop: bool = False,
-) -> gpd.GeoSeries | gpd.GeoDataFrame:
+) -> gpd.GeoDataFrame:
     """
     Generate :obj:`~geopandas.GeoDataFrame` of geometries from 'WKT' column of
     :obj:`~pandas.DataFrame`.
@@ -93,4 +101,4 @@ def from_wkt(
         df.drop_or_not(drop=drop, columns=column),
         geometry=gpd.GeoSeries.from_wkt(df[column]),
         crs=crs,
-    ).to_series()
+    )

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -50,8 +50,10 @@ def from_wkt(
 
     Returns
     -------
-    GeoSeries or GeoDataFrame
-        GeoSeries if dropped ``df`` is empty else GeoDataFrame.
+    GeoDataFrame
+        .. deprecated:: 0.0.17
+            The result doesn't support returning 'GeoSeries' anymore, even one column
+            'GeoDataFrame'. (Warning added DToolKit 0.0.17)
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -93,10 +93,10 @@ def from_wkt(
     Drop original 'wkt' column.
 
     >>> df.from_wkt("wkt", drop=True)
-    0    POINT (1.00000 1.00000)
-    1    POINT (2.00000 2.00000)
-    2    POINT (3.00000 3.00000)
-    Name: geometry, dtype: geometry
+                      geometry
+    0  POINT (1.00000 1.00000)
+    1  POINT (2.00000 2.00000)
+    2  POINT (3.00000 3.00000)
     """
 
     return gpd.GeoDataFrame(

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -7,7 +7,6 @@ import geopandas as gpd
 import pandas as pd
 
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
-from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.util._decorator import warning
 

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -53,7 +53,7 @@ def from_wkt(
     GeoDataFrame
         .. deprecated:: 0.0.17
             The result doesn't support returning 'GeoSeries' anymore, even one column
-            'GeoDataFrame'. (Warning added DToolKit 0.0.17)
+            'GeoDataFrame'.
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -62,7 +62,7 @@ def from_xy(
     GeoDataFrame
         .. deprecated:: 0.0.17
             The result doesn't support returning 'GeoSeries' anymore, even one column
-            'GeoDataFrame'. (Warning added DToolKit 0.0.17)
+            'GeoDataFrame'.
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -92,9 +92,9 @@ def from_xy(
     Drop original 'x' and 'y' columns.
 
     >>> df.points_from_xy("x", "y", drop=True, crs=4326)
-    0    POINT (122.00000 55.00000)
-    1     POINT (100.00000 1.00000)
-    Name: geometry, dtype: geometry
+                         geometry
+    0  POINT (122.00000 55.00000)
+    1   POINT (100.00000 1.00000)
     """
 
     return gpd.GeoDataFrame(

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -9,6 +9,7 @@ import pandas as pd
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
 from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
+from dtoolkit.util._decorator import warning
 
 if TYPE_CHECKING:
     from pyproj import CRS
@@ -16,6 +17,13 @@ if TYPE_CHECKING:
 
 @register_dataframe_method("points_from_xy")
 @register_dataframe_method
+@warning(
+    (
+        "The result doesn't support returning 'GeoSeries' anymore, "
+        "even one column 'GeoDataFrame'. (Warning added DToolKit 0.0.17)"
+    ),
+    stacklevel=3,
+)
 def from_xy(
     df: pd.DataFrame,
     x: Hashable,
@@ -23,7 +31,7 @@ def from_xy(
     z: Hashable = None,
     crs: CRS | str | int = None,
     drop: bool = False,
-) -> gpd.GeoSeries | gpd.GeoDataFrame:
+) -> gpd.GeoDataFrame:
     """
     Generate :obj:`~geopandas.GeoDataFrame` of :obj:`~shapely.geometry.Point`
     geometries from columns of :obj:`~pandas.DataFrame`.
@@ -95,4 +103,4 @@ def from_xy(
             z=df[z] if z is not None else z,
         ),
         crs=crs,
-    ).to_series()
+    )

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -59,8 +59,10 @@ def from_xy(
 
     Returns
     -------
-    GeoSeries or GeoDataFrame
-        GeoSeries if dropped ``df`` is empty else GeoDataFrame.
+    GeoDataFrame
+        .. deprecated:: 0.0.17
+            The result doesn't support returning 'GeoSeries' anymore, even one column
+            'GeoDataFrame'. (Warning added DToolKit 0.0.17)
 
     See Also
     --------

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -7,7 +7,6 @@ import geopandas as gpd
 import pandas as pd
 
 from dtoolkit.accessor.dataframe import drop_or_not  # noqa
-from dtoolkit.accessor.dataframe import to_series  # noqa
 from dtoolkit.accessor.register import register_dataframe_method
 from dtoolkit.util._decorator import warning
 

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -54,11 +54,11 @@ def to_geoframe(
     ...     .from_xy("x", "y", drop=True, crs=4326)
     ... )
     >>> df_point
-    0    POINT (122.00000 55.00000)
-    1     POINT (100.00000 1.00000)
-    Name: geometry, dtype: geometry
+                         geometry
+    0  POINT (122.00000 55.00000)
+    1   POINT (100.00000 1.00000)
     >>> df_data = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    >>> df = pd.concat([df_data, df_point], axis=1)
+    >>> df = pd.concat((df_data, df_point), axis=1)
     >>> df
        a  b                    geometry
     0  1  3  POINT (122.00000 55.00000)

--- a/dtoolkit/geoaccessor/geoseries/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/count_coordinates.py
@@ -45,8 +45,10 @@ def count_coordinates(s: gpd.GeoSeries) -> pd.Series:
     --------
     dtoolkit.geoaccessor.geoseries.count_coordinates
         Counts the number of coordinate pairs in each geometry of GeoSeries.
+
     dtoolkit.geoaccessor.geodataframe.count_coordinates
         Counts the number of coordinate pairs in each geometry of GeoDataFrame.
+
     pygeos.coordinates.count_coordinates
         The core algorithm of this accessor.
     {examples}

--- a/dtoolkit/geoaccessor/geoseries/get_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/get_coordinates.py
@@ -51,8 +51,10 @@ def get_coordinates(s: gpd.GeoSeries, **kwargs) -> pd.Series:
     --------
     dtoolkit.geoaccessor.geoseries.get_coordinates
         Gets coordinates from each geometry of GeoSeries.
+
     dtoolkit.geoaccessor.geodataframe.get_coordinates
         Gets coordinates from each geometry of GeoDataFrame.
+
     pygeos.coordinates.get_coordinates
         The core algorithm of this accessor.
     {examples}

--- a/dtoolkit/geoaccessor/geoseries/utm_crs.py
+++ b/dtoolkit/geoaccessor/geoseries/utm_crs.py
@@ -25,10 +25,13 @@ def utm_crs(s: gpd.GeoSeries, datum_name: str = "WGS 84") -> pd.Series:
     --------
     dtoolkit.geoaccessor.geoseries.utm_crs
         Returns the estimated UTM CRS based on the bounds of each geometry.
+
     dtoolkit.geoaccessor.geodataframe.utm_crs
         Returns the estimated UTM CRS based on the bounds of each geometry.
+
     geopandas.GeoSeries.estimate_utm_crs
         Returns the estimated UTM CRS based on the bounds of the dataset.
+
     geopandas.GeoDataFrame.estimate_utm_crs
         Returns the estimated UTM CRS based on the bounds of the dataset.
 

--- a/test/geoaccessor/dataframe/test_from_xy.py
+++ b/test/geoaccessor/dataframe/test_from_xy.py
@@ -125,13 +125,12 @@ from dtoolkit.geoaccessor.dataframe import from_xy  # noqa
             "z",
             None,
             True,
-            gpd.GeoSeries(
-                [
+            gpd.GeoDataFrame(
+                geometry=[
                     Point(122, 55, 0),
                     Point(100, 1, 0),
                     Point(0, 0, 0),
                 ],
-                name="Geometry",
             ),
         ),
         # test drop is True

--- a/test/geoaccessor/geodataframe/test_drop_geometry.py
+++ b/test/geoaccessor/geodataframe/test_drop_geometry.py
@@ -33,7 +33,9 @@ from dtoolkit.geoaccessor.geodataframe import drop_geometry  # noqa
         (
             (
                 pd.DataFrame({"x": [122, 100], "y": [55, 1]}).from_xy(
-                    "x", "y", drop=True
+                    "x",
+                    "y",
+                    drop=True,
                 )
             ),
             pd.DataFrame(index=[0, 1]),

--- a/test/geoaccessor/geodataframe/test_drop_geometry.py
+++ b/test/geoaccessor/geodataframe/test_drop_geometry.py
@@ -32,8 +32,9 @@ from dtoolkit.geoaccessor.geodataframe import drop_geometry  # noqa
         # test single column dataframe
         (
             (
-                pd.DataFrame({"x": [122, 100], "y": [55, 1]})
-                .from_xy("x", "y", drop=True)
+                pd.DataFrame({"x": [122, 100], "y": [55, 1]}).from_xy(
+                    "x", "y", drop=True
+                )
             ),
             pd.DataFrame(index=[0, 1]),
         ),

--- a/test/geoaccessor/geodataframe/test_drop_geometry.py
+++ b/test/geoaccessor/geodataframe/test_drop_geometry.py
@@ -34,7 +34,6 @@ from dtoolkit.geoaccessor.geodataframe import drop_geometry  # noqa
             (
                 pd.DataFrame({"x": [122, 100], "y": [55, 1]})
                 .from_xy("x", "y", drop=True)
-                .to_frame()
             ),
             pd.DataFrame(index=[0, 1]),
         ),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

1. to keep the same data type, before action and after
2. like pandas `df.drop`, the result of return is still DataFrame even one column data
