### PR TITLE
TST: Use `assert_*_equal` replace `.equals` in testing

### DIFF
--- a/test/accessor/dataframe/test_to_series.py
+++ b/test/accessor/dataframe/test_to_series.py
@@ -1,6 +1,8 @@
 import geopandas as gpd
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
+from pandas.testing import assert_series_equal
 
 from dtoolkit.accessor.dataframe import to_series  # noqa: F401
 
@@ -172,7 +174,10 @@ from dtoolkit.accessor.dataframe import to_series  # noqa: F401
 def test_work(df, name, index_column, value_column, expected):
     result = df.to_series(name, index_column, value_column)
 
-    assert result.equals(expected)
+    if isinstance(expected, pd.Series):
+        assert_series_equal(result, expected)
+    else:
+        assert_frame_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/geoaccessor/test_register.py
+++ b/test/geoaccessor/test_register.py
@@ -1,6 +1,7 @@
 import geopandas as gpd
 import pandas as pd
 import pytest
+from pandas.testing import assert_series_equal
 from pygeos import count_coordinates
 from pygeos import from_shapely
 
@@ -60,18 +61,18 @@ def test_method_hooked_exist(data, attr):
 @pytest.mark.parametrize(
     "data, name, expected",
     [
-        (s, "counts", pd.Series([1, 1, 0], name="geometry")),
+        (s, "counts", pd.Series([1, 1, 0])),
         (d, "counts", pd.Series([1, 1, 0], name="geometry")),
-        (s, "counts_1", pd.Series([1, 1, 0], name="geometry")),
+        (s, "counts_1", pd.Series([1, 1, 0])),
         (d, "counts_1", pd.Series([1, 1, 0], name="geometry")),
-        (s, "counts_it", pd.Series([1, 1, 0], name="geometry")),
+        (s, "counts_it", pd.Series([1, 1, 0])),
         (d, "counts_it", pd.Series([1, 1, 0], name="geometry")),
     ],
 )
 def test_work(data, name, expected):
     result = getattr(data, name)()
 
-    assert result.equals(expected)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(

--- a/test/transformer/pandas/test_GetTF.py
+++ b/test/transformer/pandas/test_GetTF.py
@@ -1,5 +1,9 @@
 import pytest
 
+import pandas as pd
+from pandas.testing import assert_frame_equal
+from pandas.testing import assert_series_equal
+
 from dtoolkit.transformer import GetTF
 from test.transformer.conftest import df_iris
 from test.transformer.conftest import feature_names
@@ -12,4 +16,7 @@ def test_work(cols):
     result = tf.fit_transform(df_iris)
     expected = df_iris[cols]
 
-    assert result.equals(expected)
+    if isinstance(expected, pd.Series):
+        assert_series_equal(result, expected)
+    else:
+        assert_frame_equal(result, expected)

--- a/test/transformer/pandas/test_GetTF.py
+++ b/test/transformer/pandas/test_GetTF.py
@@ -1,6 +1,5 @@
-import pytest
-
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 from pandas.testing import assert_series_equal
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #xxxx
- [x] whatsnew entry

patch to #607