### PR TITLE
MAINT: Set only positional parameter for `(geo)accessor`

### DIFF
--- a/doc/source/guide/workflow.md
+++ b/doc/source/guide/workflow.md
@@ -73,7 +73,7 @@ But `Data Preprocessing` still needs to write code.
 
 ![Store data pipeline](../_static/store-data-pipeline.svg)
 
-This is a store data complete pipeline what we have seen at [Transformer and Pipeline Quickstart](transformer_quickstart.ipynb#The-dtoolkit.transformer-Way).
+This is a store data complete pipeline what we have seen at [Transformer and Pipeline Quickstart](transformer_quickstart.ipynb).
 
 All jobs in `Pipeline`, from `Data Cleaning` to `Data Preprocessing`, from `Feature Engineering` to `Regression`.
 

--- a/doc/source/reference/geoaccessor.rst
+++ b/doc/source/reference/geoaccessor.rst
@@ -30,7 +30,7 @@ GeoDataFrame Accessor
 
 
 Series Accessor (to GeoPandas)
----------------
+------------------------------
 .. currentmodule:: dtoolkit.geoaccessor.series
 .. autosummary::
     :toctree: api/

--- a/doc/source/reference/pipeline.rst
+++ b/doc/source/reference/pipeline.rst
@@ -2,21 +2,10 @@
 Pipeline
 ========
 .. currentmodule:: dtoolkit.pipeline
-
-
-Pipeline
---------
 .. autosummary::
     :toctree: api/
 
     Pipeline
-    make_pipeline
-
-
-FeatureUnion
-------------
-.. autosummary::
-    :toctree: api/
-
     FeatureUnion
+    make_pipeline
     make_union

--- a/dtoolkit/accessor/dataframe/boolean.py
+++ b/dtoolkit/accessor/dataframe/boolean.py
@@ -10,6 +10,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 @register_dataframe_method
 def boolean(
     df: pd.DataFrame,
+    /,
     how: Literal["any", "all"] = "any",
     complement: bool = False,
     **kwargs,

--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -8,7 +8,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 
 
 @register_dataframe_method
-def cols(df: pd.DataFrame, to_list: bool = False) -> list[Hashable]:
+def cols(df: pd.DataFrame, /, to_list: bool = False) -> list[Hashable]:
     """
     An API to gather :attr:`~pandas.Series.name` and
     :attr:`~pandas.DataFrame.columns` to one.

--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -17,7 +17,7 @@ def cols(df: pd.DataFrame, /, to_list: bool = False) -> list[Hashable]:
     ----------
     to_list : bool, default False
         This option doesn't work, and it's used to fit
-        :method:`dtoolkit.accessor.series.cols` arguments.
+        :func:`dtoolkit.accessor.series.cols` arguments.
 
     Returns
     -------

--- a/dtoolkit/accessor/dataframe/decompose.py
+++ b/dtoolkit/accessor/dataframe/decompose.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 @register_dataframe_method
 def decompose(
     df: pd.DataFrame,
+    /,
     method: TransformerMixin,
     columns: None
     | dict[Hashable | tuple[Hashable], Hashable | list[Hashable] | tuple[Hashable]]

--- a/dtoolkit/accessor/dataframe/drop_inf.py
+++ b/dtoolkit/accessor/dataframe/drop_inf.py
@@ -14,6 +14,7 @@ from dtoolkit.accessor.series.drop_inf import get_inf_range
 @register_dataframe_method
 def drop_inf(
     df: pd.DataFrame,
+    /,
     axis: Axis = 0,
     how: Literal["any", "all"] = "any",
     inf: Literal["all", "pos", "neg"] = "all",

--- a/dtoolkit/accessor/dataframe/drop_or_not.py
+++ b/dtoolkit/accessor/dataframe/drop_or_not.py
@@ -4,7 +4,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 
 
 @register_dataframe_method
-def drop_or_not(df: pd.DataFrame, drop: bool = True, **kwargs) -> pd.DataFrame:
+def drop_or_not(df: pd.DataFrame, /, drop: bool = True, **kwargs) -> pd.DataFrame:
     """
     Drop specified labels from rows or columns.
 

--- a/dtoolkit/accessor/dataframe/expand.py
+++ b/dtoolkit/accessor/dataframe/expand.py
@@ -79,6 +79,7 @@ from dtoolkit.accessor.series import expand as s_expand
 )
 def expand(
     df: pd.DataFrame,
+    /,
     suffix: list[Hashable] = None,
     delimiter: str = "_",
     flatten: bool = False,

--- a/dtoolkit/accessor/dataframe/fillna_regression.py
+++ b/dtoolkit/accessor/dataframe/fillna_regression.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 @register_dataframe_method
 def fillna_regression(
     df: pd.DataFrame,
+    /,
     method: RegressorMixin,
     columns: dict[Hashable, Hashable | list[Hashable] | pd.Index],
     how: str = "na",

--- a/dtoolkit/accessor/dataframe/fillna_regression.py
+++ b/dtoolkit/accessor/dataframe/fillna_regression.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Hashable
+from typing import Literal
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -17,7 +18,7 @@ def fillna_regression(
     /,
     method: RegressorMixin,
     columns: dict[Hashable, Hashable | list[Hashable] | pd.Index],
-    how: str = "na",
+    how: Literal["na", "all"] = "na",
     **kwargs,
 ) -> pd.DataFrame:
     """

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -14,8 +14,8 @@ from dtoolkit.accessor.register import register_dataframe_method
 @register_dataframe_method
 def filter_in(
     df: pd.DataFrame,
-    /,
     condition: Iterable | SeriesOrFrame | dict[Hashable, list[Hashable]],
+    /,
     how: Literal["any", "all"] = "all",
     complement: bool = False,
 ) -> pd.DataFrame:

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -14,6 +14,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 @register_dataframe_method
 def filter_in(
     df: pd.DataFrame,
+    /,
     condition: Iterable | SeriesOrFrame | dict[Hashable, list[Hashable]],
     how: Literal["any", "all"] = "all",
     complement: bool = False,

--- a/dtoolkit/accessor/dataframe/repeat.py
+++ b/dtoolkit/accessor/dataframe/repeat.py
@@ -10,6 +10,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 @register_dataframe_method
 def repeat(
     df: pd.DataFrame,
+    /,
     repeats: int | list[int],
     axis: Axis = 0,
 ) -> pd.DataFrame:

--- a/dtoolkit/accessor/dataframe/repeat.py
+++ b/dtoolkit/accessor/dataframe/repeat.py
@@ -10,8 +10,8 @@ from dtoolkit.accessor.register import register_dataframe_method
 @register_dataframe_method
 def repeat(
     df: pd.DataFrame,
-    /,
     repeat: int | list[int],
+    /,
     axis: Axis = 0,
 ) -> pd.DataFrame:
     """

--- a/dtoolkit/accessor/dataframe/repeat.py
+++ b/dtoolkit/accessor/dataframe/repeat.py
@@ -11,7 +11,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 def repeat(
     df: pd.DataFrame,
     /,
-    repeats: int | list[int],
+    repeat: int | list[int],
     axis: Axis = 0,
 ) -> pd.DataFrame:
     """
@@ -24,7 +24,7 @@ def repeat(
 
     Parameters
     ----------
-    repeats : int or array of ints
+    repeat : int or array of ints
         The number of repetitions for each element. This should be a
         non-negative integer. Repeating 0 times will return an empty
         :obj:`~pandas.DataFrame`.
@@ -82,9 +82,9 @@ def repeat(
     return pd.DataFrame(
         np.repeat(
             df._values,
-            repeats,
+            repeat,
             axis=axis,
         ),
-        index=df.index.repeat(repeats) if axis == 0 else df.index,
-        columns=df.columns.repeat(repeats) if axis == 1 else df.columns,
+        index=df.index.repeat(repeat) if axis == 0 else df.index,
+        columns=df.columns.repeat(repeat) if axis == 1 else df.columns,
     )

--- a/dtoolkit/accessor/dataframe/to_series.py
+++ b/dtoolkit/accessor/dataframe/to_series.py
@@ -11,6 +11,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 @register_dataframe_method
 def to_series(
     df: pd.DataFrame,
+    /,
     name: Hashable = None,
     index_column: Hashable = None,
     value_column: Hashable = None,

--- a/dtoolkit/accessor/dataframe/top_n.py
+++ b/dtoolkit/accessor/dataframe/top_n.py
@@ -11,8 +11,8 @@ from dtoolkit.accessor.series import top_n as s_top_n
 @register_dataframe_method
 def top_n(
     df: pd.DataFrame,
-    /,
     n: int,
+    /,
     largest: bool = True,
     keep: Literal["first", "last", "all"] = "first",
     prefix: str = "top",

--- a/dtoolkit/accessor/dataframe/top_n.py
+++ b/dtoolkit/accessor/dataframe/top_n.py
@@ -11,6 +11,7 @@ from dtoolkit.accessor.series import top_n as s_top_n
 @register_dataframe_method
 def top_n(
     df: pd.DataFrame,
+    /,
     n: int,
     largest: bool = True,
     keep: Literal["first", "last", "all"] = "first",

--- a/dtoolkit/accessor/dataframe/top_n.py
+++ b/dtoolkit/accessor/dataframe/top_n.py
@@ -146,7 +146,7 @@ def top_n(
     return df.apply(
         wrap_s_top_n,
         axis=1,
-        n=n,
+        args=(n,),
         largest=largest,
         keep=keep,
     ).add_prefix(prefix + delimiter)

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -33,7 +33,7 @@ def values_to_dict(
         If True would drop duplicate elements.
 
     to_list : bool, default True
-        If True one element value will return :keyword:`list`.
+        If True one element value will return :class:`list`.
 
     Returns
     -------

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -11,6 +11,7 @@ from dtoolkit.accessor.series import values_to_dict as s_values_to_dict  # noqa:
 @register_dataframe_method
 def values_to_dict(
     df: pd.DataFrame,
+    /,
     order: list[Hashable] | pd.Index = None,
     ascending: bool = True,
     unique: bool = True,

--- a/dtoolkit/accessor/index/to_set.py
+++ b/dtoolkit/accessor/index/to_set.py
@@ -8,7 +8,7 @@ from dtoolkit.accessor.register import register_index_method
 
 
 @register_index_method
-def to_set(index: pd.Index, level: int | Hashable = None) -> set:
+def to_set(index: pd.Index, /, level: int | Hashable = None) -> set:
     """
     Return a :keyword:`set` of the values.
 

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -35,7 +35,7 @@ def register_method_factory(register_accessor):
     # based on pandas_flavor/register.py
     def register_accessor_method(method: Callable, name: str):
         @wraps(method)
-        def method_accessor(pd_obj: SeriesOrFrame):
+        def method_accessor(pd_obj: SeriesOrFrame, /):
             @wraps(method)
             def wrapper(*args, **kwargs):
                 return method(pd_obj, *args, **kwargs)

--- a/dtoolkit/accessor/series/bin.py
+++ b/dtoolkit/accessor/series/bin.py
@@ -4,7 +4,7 @@ from dtoolkit.accessor.register import register_series_method
 
 
 @register_series_method
-def bin(s: pd.Series, *args, **kwargs) -> pd.Series:
+def bin(s: pd.Series, /, *args, **kwargs) -> pd.Series:
     """
     Bin values into discrete intervals.
 

--- a/dtoolkit/accessor/series/cols.py
+++ b/dtoolkit/accessor/series/cols.py
@@ -10,6 +10,7 @@ from dtoolkit.accessor.register import register_series_method
 @register_series_method
 def cols(
     s: pd.Series,
+    /,
     to_list: bool = False,
 ) -> Hashable | None | list[Hashable | None]:
     """

--- a/dtoolkit/accessor/series/drop_inf.py
+++ b/dtoolkit/accessor/series/drop_inf.py
@@ -9,7 +9,7 @@ from dtoolkit.accessor.register import register_series_method
 
 
 @register_series_method
-def drop_inf(s: pd.Series, inf: Literal["all", "pos", "neg"] = "all") -> pd.Series:
+def drop_inf(s: pd.Series, /, inf: Literal["all", "pos", "neg"] = "all") -> pd.Series:
     """
     Remove ``inf`` values.
 

--- a/dtoolkit/accessor/series/error_report.py
+++ b/dtoolkit/accessor/series/error_report.py
@@ -12,6 +12,7 @@ from dtoolkit.accessor.register import register_series_method
 @register_series_method
 def error_report(
     s: pd.Series,
+    /,
     predicted: OneDimArray | list[Number],
     columns: list[Hashable] = None,
 ) -> pd.DataFrame:

--- a/dtoolkit/accessor/series/error_report.py
+++ b/dtoolkit/accessor/series/error_report.py
@@ -12,8 +12,8 @@ from dtoolkit.accessor.register import register_series_method
 @register_series_method
 def error_report(
     s: pd.Series,
-    /,
     predicted: OneDimArray | list[Number],
+    /,
     columns: list[Hashable] = None,
 ) -> pd.DataFrame:
     """

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -72,6 +72,7 @@ from dtoolkit.accessor.register import register_series_method
 )
 def expand(
     s: pd.Series,
+    /,
     suffix: list[Hashable] = None,
     delimiter: str = "_",
     flatten: bool = False,

--- a/dtoolkit/accessor/series/getattr.py
+++ b/dtoolkit/accessor/series/getattr.py
@@ -5,7 +5,7 @@ from dtoolkit.accessor.series._getattr_helper import get_attr
 
 
 @register_series_method
-def getattr(s: pd.Series, name: str, *args, **kwargs) -> pd.Series:
+def getattr(s: pd.Series, name: str, /, *args, **kwargs) -> pd.Series:
     """
     Return the value of the named attribute of Series element.
 

--- a/dtoolkit/accessor/series/len.py
+++ b/dtoolkit/accessor/series/len.py
@@ -7,7 +7,7 @@ from dtoolkit.accessor.register import register_series_method
 
 
 @register_series_method
-def len(s: pd.Series, number: int = 1, other: int = None) -> pd.Series:
+def len(s: pd.Series, /, number: int = 1, other: int = None) -> pd.Series:
     """
     Return the length of each element in the series.
 

--- a/dtoolkit/accessor/series/to_set.py
+++ b/dtoolkit/accessor/series/to_set.py
@@ -4,7 +4,7 @@ from dtoolkit.accessor.register import register_series_method
 
 
 @register_series_method
-def to_set(s: pd.Series) -> set:
+def to_set(s: pd.Series, /) -> set:
     """
     Return a :keyword:`set` of the values.
 

--- a/dtoolkit/accessor/series/top_n.py
+++ b/dtoolkit/accessor/series/top_n.py
@@ -11,6 +11,7 @@ from dtoolkit.accessor.register import register_series_method
 def top_n(
     s: pd.Series,
     n: int,
+    /,
     largest: bool = True,
     keep: Literal["first", "last", "all"] = "first",
 ) -> pd.Series:

--- a/dtoolkit/accessor/series/values_to_dict.py
+++ b/dtoolkit/accessor/series/values_to_dict.py
@@ -22,7 +22,7 @@ def values_to_dict(
         If True would drop duplicate elements.
 
     to_list : bool, default True
-        If True one element value will return :keyword:`list`.
+        If True one element value will return :class:`list`.
 
     Returns
     -------

--- a/dtoolkit/accessor/series/values_to_dict.py
+++ b/dtoolkit/accessor/series/values_to_dict.py
@@ -6,7 +6,12 @@ from dtoolkit.accessor.register import register_series_method  # noqa: F401
 
 
 @register_series_method
-def values_to_dict(s: pd.Series, unique: bool = True, to_list: bool = True) -> dict:
+def values_to_dict(
+    s: pd.Series,
+    /,
+    unique: bool = True,
+    to_list: bool = True,
+) -> dict:
     """
     Convert :attr:`~pandas.Series.index` and :attr:`~pandas.Series.values` to
     :class:`dict`.

--- a/dtoolkit/geoaccessor/accessor.py
+++ b/dtoolkit/geoaccessor/accessor.py
@@ -95,7 +95,7 @@ def register_geoseries_accessor(name: str):
 
         In [5]: d = s.to_frame("geometry")
         Out[5]:
-                        geometry
+                          geometry
         0  POINT (0.00000 0.00000)
         1  POINT (1.00000 1.00000)
         2                     None

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 def from_wkb(
     df: pd.DataFrame,
     column: Hashable,
+    /,
     crs: CRS | str | int = None,
     drop: bool = False,
 ) -> gpd.GeoDataFrame:

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 def from_wkt(
     df: pd.DataFrame,
     column: Hashable,
+    /,
     crs: CRS | str | int = None,
     drop: bool = False,
 ) -> gpd.GeoDataFrame:

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 )
 def from_xy(
     df: pd.DataFrame,
+    /,
     x: Hashable,
     y: Hashable,
     z: Hashable = None,

--- a/dtoolkit/geoaccessor/dataframe/geocode.py
+++ b/dtoolkit/geoaccessor/dataframe/geocode.py
@@ -11,6 +11,7 @@ from dtoolkit.accessor.register import register_dataframe_method
 def geocode(
     df: pd.DataFrame,
     column: Hashable,
+    /,
     drop: bool = False,
     **kwargs,
 ) -> gpd.GeoDataFrame:

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 @register_dataframe_method
 def to_geoframe(
     df: pd.DataFrame,
+    /,
     crs: CRS | str | int = None,
     geometry: Hashable | gpd.GeoSeries = None,
     **kwargs,

--- a/dtoolkit/geoaccessor/geodataframe/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geodataframe/count_coordinates.py
@@ -33,5 +33,5 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
     """,
     ),
 )
-def count_coordinates(df: gpd.GeoDataFrame) -> pd.Series:
+def count_coordinates(df: gpd.GeoDataFrame, /) -> pd.Series:
     return df.geometry.count_coordinates()

--- a/dtoolkit/geoaccessor/geodataframe/drop_geometry.py
+++ b/dtoolkit/geoaccessor/geodataframe/drop_geometry.py
@@ -5,7 +5,7 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 
 @register_geodataframe_method
-def drop_geometry(df: gpd.GeoDataFrame) -> pd.DataFrame:
+def drop_geometry(df: gpd.GeoDataFrame, /) -> pd.DataFrame:
     """
     Drop the activate geometry column from the :class:`~geopandas.GeoDataFrame`
     to return a normal :class:`~pandas.DataFrame`.

--- a/dtoolkit/geoaccessor/geodataframe/geobuffer.py
+++ b/dtoolkit/geoaccessor/geodataframe/geobuffer.py
@@ -51,9 +51,9 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 def geobuffer(
     df: gpd.GeoDataFrame,
     distance: Number | list[Number] | OneDimArray,
+    /,
     **kwargs,
 ) -> gpd.GeoDataFrame:
-
     return df.assign(
         **{
             df.geometry.name: df.geometry.geobuffer(

--- a/dtoolkit/geoaccessor/geodataframe/get_coordinates.py
+++ b/dtoolkit/geoaccessor/geodataframe/get_coordinates.py
@@ -33,5 +33,5 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
     """,
     ),
 )
-def get_coordinates(df: gpd.GeoDataFrame, **kwargs) -> pd.Series:
+def get_coordinates(df: gpd.GeoDataFrame, /, **kwargs) -> pd.Series:
     return df.geometry.get_coordinates(**kwargs)

--- a/dtoolkit/geoaccessor/geodataframe/reverse_geocode.py
+++ b/dtoolkit/geoaccessor/geodataframe/reverse_geocode.py
@@ -6,7 +6,7 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 
 @register_geodataframe_method
-def reverse_geocode(df: gpd.GeoDataFrame, **kwargs) -> gpd.GeoDataFrame:
+def reverse_geocode(df: gpd.GeoDataFrame, /, **kwargs) -> gpd.GeoDataFrame:
     """
     Reverse geocode :obj:`~shapely.geometry.Point` type :class:`~geopandas.GeoDataFrame`
     and get the corresponding addresses.

--- a/dtoolkit/geoaccessor/geodataframe/utm_crs.py
+++ b/dtoolkit/geoaccessor/geodataframe/utm_crs.py
@@ -10,5 +10,5 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 @register_geodataframe_method
 @doc(s_utm_crs)
-def utm_crs(df: gpd.GeoDataFrame, datum_name: str = "WGS 84", /) -> pd.Series:
+def utm_crs(df: gpd.GeoDataFrame, /, datum_name: str = "WGS 84") -> pd.Series:
     return df.geometry.utm_crs(datum_name=datum_name)

--- a/dtoolkit/geoaccessor/geodataframe/utm_crs.py
+++ b/dtoolkit/geoaccessor/geodataframe/utm_crs.py
@@ -10,5 +10,5 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 @register_geodataframe_method
 @doc(s_utm_crs)
-def utm_crs(df: gpd.GeoDataFrame, datum_name: str = "WGS 84") -> pd.Series:
+def utm_crs(df: gpd.GeoDataFrame, datum_name: str = "WGS 84", /) -> pd.Series:
     return df.geometry.utm_crs(datum_name=datum_name)

--- a/dtoolkit/geoaccessor/geoseries/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/count_coordinates.py
@@ -31,7 +31,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
     """,
     ),
 )
-def count_coordinates(s: gpd.GeoSeries) -> pd.Series:
+def count_coordinates(s: gpd.GeoSeries, /) -> pd.Series:
     """
     Counts the number of coordinate pairs in each geometry of {klass}.
 

--- a/dtoolkit/geoaccessor/geoseries/geobuffer.py
+++ b/dtoolkit/geoaccessor/geoseries/geobuffer.py
@@ -50,6 +50,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 def geobuffer(
     s: gpd.GeoSeries,
     distance: Number | list[Number] | OneDimArray,
+    /,
     **kwargs,
 ) -> gpd.GeoSeries:
     """

--- a/dtoolkit/geoaccessor/geoseries/get_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/get_coordinates.py
@@ -31,7 +31,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
     """,
     ),
 )
-def get_coordinates(s: gpd.GeoSeries, **kwargs) -> pd.Series:
+def get_coordinates(s: gpd.GeoSeries, /, **kwargs) -> pd.Series:
     """
     Gets coordinates from each geometry of {klass}.
 

--- a/dtoolkit/geoaccessor/geoseries/reverse_geocode.py
+++ b/dtoolkit/geoaccessor/geoseries/reverse_geocode.py
@@ -4,7 +4,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-def reverse_geocode(s: gpd.GeoSeries, **kwargs) -> gpd.GeoDataFrame:
+def reverse_geocode(s: gpd.GeoSeries, /, **kwargs) -> gpd.GeoDataFrame:
     """
     Reverse geocode :obj:`~shapely.geometry.Point` type :class:`~geopandas.GeoSeries`
     and get the corresponding addresses.

--- a/dtoolkit/geoaccessor/geoseries/utm_crs.py
+++ b/dtoolkit/geoaccessor/geoseries/utm_crs.py
@@ -7,7 +7,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-def utm_crs(s: gpd.GeoSeries, datum_name: str = "WGS 84") -> pd.Series:
+def utm_crs(s: gpd.GeoSeries, datum_name: str = "WGS 84", /) -> pd.Series:
     """
     Returns the estimated UTM CRS based on the bounds of each geometry.
 

--- a/dtoolkit/geoaccessor/geoseries/utm_crs.py
+++ b/dtoolkit/geoaccessor/geoseries/utm_crs.py
@@ -7,7 +7,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-def utm_crs(s: gpd.GeoSeries, datum_name: str = "WGS 84", /) -> pd.Series:
+def utm_crs(s: gpd.GeoSeries, /, datum_name: str = "WGS 84") -> pd.Series:
     """
     Returns the estimated UTM CRS based on the bounds of each geometry.
 

--- a/dtoolkit/geoaccessor/series/from_wkb.py
+++ b/dtoolkit/geoaccessor/series/from_wkb.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 @register_series_method
 def from_wkb(
     s: pd.Series,
+    /,
     crs: CRS | str | int = None,
     drop: bool = False,
 ) -> gpd.GeoSeries | gpd.GeoDataFrame:

--- a/dtoolkit/geoaccessor/series/from_wkt.py
+++ b/dtoolkit/geoaccessor/series/from_wkt.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 @register_series_method
 def from_wkt(
     s: pd.Series,
+    /,
     crs: CRS | str | int = None,
     drop: bool = False,
 ) -> gpd.GeoSeries | gpd.GeoDataFrame:

--- a/dtoolkit/geoaccessor/series/geocode.py
+++ b/dtoolkit/geoaccessor/series/geocode.py
@@ -5,7 +5,7 @@ from dtoolkit.accessor.register import register_series_method
 
 
 @register_series_method
-def geocode(s: pd.Series, drop: bool = False, **kwargs) -> gpd.GeoDataFrame:
+def geocode(s: pd.Series, /, drop: bool = False, **kwargs) -> gpd.GeoDataFrame:
     """
     Geocode string type Series and get a GeoDataFrame of the resulting points.
 

--- a/dtoolkit/geoaccessor/series/to_geoseries.py
+++ b/dtoolkit/geoaccessor/series/to_geoseries.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 @register_series_method
 def to_geoseries(
     s: pd.Series,
+    /,
     crs: CRS | str | int = None,
     **kwargs,
 ) -> gpd.GeoSeries | pd.Series:

--- a/test/accessor/dataframe/test_filter_in.py
+++ b/test/accessor/dataframe/test_filter_in.py
@@ -152,7 +152,7 @@ df = pd.DataFrame(
     ],
 )
 def test_work(condition, kwargs, expected):
-    result = df.filter_in(condition=condition, **kwargs)
+    result = df.filter_in(condition, **kwargs)
 
     assert_frame_equal(result, expected)
 

--- a/test/accessor/dataframe/test_repeat.py
+++ b/test/accessor/dataframe/test_repeat.py
@@ -45,7 +45,7 @@ from dtoolkit.accessor.dataframe import repeat  # noqa: F401, F811
         ),
     ],
 )
-def test_work(repeat, axis, expected):
+def test_work(repeat, axis, expected):  # noqa: F811
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     result = df.repeat(repeat, axis=axis)
 

--- a/test/accessor/dataframe/test_repeat.py
+++ b/test/accessor/dataframe/test_repeat.py
@@ -6,7 +6,7 @@ from dtoolkit.accessor.dataframe import repeat  # noqa: F401
 
 
 @pytest.mark.parametrize(
-    "repeats, axis, expected",
+    "repeat, axis, expected",
     [
         (1, 0, pd.DataFrame({"a": [1, 2], "b": [3, 4]})),
         (1, 1, pd.DataFrame({"a": [1, 2], "b": [3, 4]})),
@@ -45,9 +45,9 @@ from dtoolkit.accessor.dataframe import repeat  # noqa: F401
         ),
     ],
 )
-def test_work(repeats, axis, expected):
+def test_work(repeat, axis, expected):
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    result = df.repeat(repeats, axis=axis)
+    result = df.repeat(repeat, axis=axis)
 
     assert_frame_equal(result, expected)
 

--- a/test/accessor/dataframe/test_repeat.py
+++ b/test/accessor/dataframe/test_repeat.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from dtoolkit.accessor.dataframe import repeat  # noqa: F401
+from dtoolkit.accessor.dataframe import repeat  # noqa: F401, F811
 
 
 @pytest.mark.parametrize(

--- a/test/accessor/dataframe/test_top_n.py
+++ b/test/accessor/dataframe/test_top_n.py
@@ -106,7 +106,7 @@ def test_single_index_work(
     )
 
     result = df.top_n(
-        n=n,
+        n,
         largest=largest,
         keep=keep,
         prefix=prefix,
@@ -149,7 +149,7 @@ def test_duplicate_dataframe(n, keep, expected):
         },
     )
 
-    result = df.top_n(n=n, keep=keep, element="both")
+    result = df.top_n(n, keep=keep, element="both")
     expected = pd.DataFrame(expected)
 
     assert_frame_equal(result, expected)
@@ -194,7 +194,7 @@ def test_duplicate_dataframe(n, keep, expected):
 )
 def test_multi_index(df, n, expected):
     df = pd.DataFrame(df)
-    result = df.top_n(n=n, element="both")
+    result = df.top_n(n, element="both")
     expected = pd.DataFrame(expected)
 
     assert_frame_equal(result, expected)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

The first parameter of `(geo)accessor` methods must be set as only positional parameter.