### PR TITLE
EHN: A sugary syntax wraps `joblib.Parallel`

### DIFF
--- a/ci/env/latest.yaml
+++ b/ci/env/latest.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pygeos
   - geopy
   - jenkspy
+  - joblib
   # testing
   - pytest
   - pytest-cov

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -126,6 +126,7 @@ intersphinx_mapping = {
     "shapely": ("https://shapely.readthedocs.io/en/stable/", None),
     "pyproj": ("https://pyproj4.github.io/pyproj/stable/", None),
     "pygeos": ("https://pygeos.readthedocs.io/en/stable/", None),
+    "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
 }
 
 # extlinks alias

--- a/doc/source/reference/utility.rst
+++ b/doc/source/reference/utility.rst
@@ -6,6 +6,13 @@ Utility
     :mod:`dtoolkit.util._decorator` and :mod:`dtoolkit.util._exception` are dtoolkit's inner packages.
 
 
+.. currentmodule:: dtoolkit.util
+.. autosummary::
+    :toctree: api/
+
+    parallelize
+
+
 _decorator
 ----------
 .. currentmodule:: dtoolkit.util._decorator

--- a/dtoolkit/util/__init__.py
+++ b/dtoolkit/util/__init__.py
@@ -1,0 +1,1 @@
+from dtoolkit.util.parallelize import parallelize

--- a/dtoolkit/util/__init__.py
+++ b/dtoolkit/util/__init__.py
@@ -1,1 +1,1 @@
-from dtoolkit.util.parallelize import parallelize
+from dtoolkit.util.parallelize import parallelize  # noqa: F401

--- a/dtoolkit/util/parallelize.py
+++ b/dtoolkit/util/parallelize.py
@@ -57,7 +57,7 @@ def parallelize(
     --------
     >>> from dtoolkit.util import parallelize
     >>> parallelize(lambda x: x ** 2, range(3))
-    >>> [0, 1, 4]
+    [0, 1, 4]
     """
     from joblib import Parallel, delayed
 

--- a/dtoolkit/util/parallelize.py
+++ b/dtoolkit/util/parallelize.py
@@ -13,7 +13,7 @@ def parallelize(
     n_jobs: int = -1,
     verbose: int = 0,
     timeout: float = None,
-    backend: Literal["loky", "multiprocessing", "threading"] = None,
+    backend: Literal["loky", "multiprocessing", "threading"] = "loky",
     require: Literal["sharedmem"] = None,
     mmap_mode: Literal[None, "r+", "r", "w+", "c"] = "r",
     **kwargs,

--- a/dtoolkit/util/parallelize.py
+++ b/dtoolkit/util/parallelize.py
@@ -11,8 +11,7 @@ def parallelize(
     n_jobs: int = -1,
     verbose: int = 0,
     timeout: float = None,
-    backend: Literal["loky", "multiprocessing", "threading"]
-    | "ParallelBackendBase" = None,
+    backend: Literal["loky", "multiprocessing", "threading"] = None,
     require: Literal["sharedmem"] = None,
     mmap_mode: Literal[None, "r+", "r", "w+", "c"] = "r",
     **kwargs,

--- a/dtoolkit/util/parallelize.py
+++ b/dtoolkit/util/parallelize.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Iterable, Literal
+from typing import Callable
+from typing import Iterable
+from typing import Literal
 
 
 def parallelize(

--- a/dtoolkit/util/parallelize.py
+++ b/dtoolkit/util/parallelize.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from functools import partial
+from typing import Callable, Iterable, Literal
+
+
+def parallelize(
+    func: Callable,
+    jobs: Iterable,
+    *,
+    n_jobs: int = -1,
+    verbose: int = 0,
+    timeout: float = None,
+    backend: Literal["loky", "multiprocessing", "threading"]
+    | "ParallelBackendBase" = None,
+    require: Literal["sharedmem"] = None,
+    mmap_mode: Literal[None, "r+", "r", "w+", "c"] = "r",
+    **kwargs,
+):
+    """
+    Parallelize ``func`` to do ``jobs``.
+
+    A sugary syntax wraps :class:`joblib.Parallel`::
+
+        from functools import partial
+
+        from joblib import Parallel, delayed
+
+        func = delayed(partial(func, **kwargs))
+        Parallel(**parallel_kwargs)(map(func, jobs))
+
+    Parameters
+    ----------
+    func : Callable
+
+    jobs : Iterable
+
+    n_jobs, verbose, timeout, backend, require, mmap_mode
+        See the documentation for :class:`joblib.Parallel` for complete details on
+        the keyword arguments.
+
+    **kwargs
+        See the documentation for ``func`` for complete details on the arguments.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        If don't have module named 'joblib'.
+
+    See Also
+    --------
+    joblib.Parallel
+    joblib.delayed
+
+    Examples
+    --------
+    >>> from dtoolkit.util import parallelize
+    >>> parallelize(lambda x: x ** 2, range(3))
+    >>> [0, 1, 4]
+    """
+    from joblib import Parallel, delayed
+
+    func = delayed(partial(func, **kwargs))
+    return Parallel(
+        n_jobs=n_jobs,
+        verbose=verbose,
+        timeout=timeout,
+        backend=backend,
+        require=require,
+        mmap_mode=mmap_mode,
+    )(map(func, jobs))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

This func could speed up io/computing

```python
from pathlib import Path

from dtoolkit.util import parallelize
import pandas as pd

df = parallelize(
    pd.read_excel,
    Path("data").glob("*.xlsx"),
    verbose=1,
)
```