### PR TITLE
DEP: Depcrated `utm_crs`

### DIFF
--- a/dtoolkit/geoaccessor/geoseries/utm_crs.py
+++ b/dtoolkit/geoaccessor/geoseries/utm_crs.py
@@ -5,7 +5,6 @@ from pyproj.database import query_utm_crs_info
 
 from dtoolkit.geoaccessor.register import register_geoseries_method
 from dtoolkit.util._decorator import warning
-from dtoolkit.util._exception import find_stack_level
 
 
 @register_geoseries_method
@@ -13,7 +12,7 @@ from dtoolkit.util._exception import find_stack_level
     "The 'utm_crs' is deprecated and will be removed in 0.0.17. "
     "(Warning added DToolKit 0.0.16)",
     DeprecationWarning,
-    find_stack_level(),
+    stacklevel=3,
 )
 def utm_crs(s: gpd.GeoSeries, /, datum_name: str = "WGS 84") -> pd.Series:
     """

--- a/dtoolkit/geoaccessor/geoseries/utm_crs.py
+++ b/dtoolkit/geoaccessor/geoseries/utm_crs.py
@@ -4,12 +4,24 @@ from pyproj.aoi import AreaOfInterest
 from pyproj.database import query_utm_crs_info
 
 from dtoolkit.geoaccessor.register import register_geoseries_method
+from dtoolkit.util._decorator import warning
+from dtoolkit.util._exception import find_stack_level
 
 
 @register_geoseries_method
+@warning(
+    "The 'utm_crs' is deprecated and will be removed in 0.0.17. "
+    "(Warning added DToolKit 0.0.16)",
+    DeprecationWarning,
+    find_stack_level(),
+)
 def utm_crs(s: gpd.GeoSeries, /, datum_name: str = "WGS 84") -> pd.Series:
     """
     Returns the estimated UTM CRS based on the bounds of each geometry.
+
+    .. deprecated:: 0.0.17
+        The 'utm_crs' is deprecated and will be removed in 0.0.17.
+        (Warning added DToolKit 0.0.16)
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

`pyproj.database.query_utm_crs_info` too slow to query all data.
For 1 point will cost 200ms but for 2000 points will cost 200s.
Even try `parallelize` to `utm_crs`, but the speed is still so lower.