### PR TITLE
EHN: New geoaccessor for Series, `to_geoframe`

### DIFF
--- a/doc/source/reference/geoaccessor.rst
+++ b/doc/source/reference/geoaccessor.rst
@@ -44,6 +44,7 @@ Series Accessor (to GeoPandas)
     from_wkb
     from_wkt
     geocode
+    to_geoframe
     to_geoseries
 
 

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -45,6 +45,7 @@ def to_geoframe(
     See Also
     --------
     dtoolkit.geoaccessor.series.to_geoseries
+    dtoolkit.geoaccessor.series.to_geoframe
 
     Examples
     --------

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -81,6 +81,35 @@ def to_geoframe(
 
     >>> type(df)
     <class 'geopandas.geodataframe.GeoDataFrame'>
+
+    Use original CRS even if its CRS is specified.
+
+    >>> df.crs == df_point.crs == 4326
+    True
+    >>> df.crs
+    <Geographic 2D CRS: EPSG:4326>
+    Name: WGS 84
+    Axis Info [ellipsoidal]:
+    - Lat[north]: Geodetic latitude (degree)
+    - Lon[east]: Geodetic longitude (degree)
+    Area of Use:
+    - name: World.
+    - bounds: (-180.0, -90.0, 180.0, 90.0)
+    Datum: World Geodetic System 1984 ensemble
+    - Ellipsoid: WGS 84
+    - Prime Meridian: Greenwich
+    >>> pd.concat((df_data, df_point), axis=1).to_geoframe(crs=3857).crs
+    <Geographic 2D CRS: EPSG:4326>
+    Name: WGS 84
+    Axis Info [ellipsoidal]:
+    - Lat[north]: Geodetic latitude (degree)
+    - Lon[east]: Geodetic longitude (degree)
+    Area of Use:
+    - name: World.
+    - bounds: (-180.0, -90.0, 180.0, 90.0)
+    Datum: World Geodetic System 1984 ensemble
+    - Ellipsoid: WGS 84
+    - Prime Meridian: Greenwich
     """
 
     return gpd.GeoDataFrame(

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -82,23 +82,11 @@ def to_geoframe(
     >>> type(df)
     <class 'geopandas.geodataframe.GeoDataFrame'>
 
-    Use original CRS even if its CRS is specified.
+    Use original CRS if its CRS is not specified.
 
     >>> df.crs == df_point.crs == 4326
     True
     >>> df.crs
-    <Geographic 2D CRS: EPSG:4326>
-    Name: WGS 84
-    Axis Info [ellipsoidal]:
-    - Lat[north]: Geodetic latitude (degree)
-    - Lon[east]: Geodetic longitude (degree)
-    Area of Use:
-    - name: World.
-    - bounds: (-180.0, -90.0, 180.0, 90.0)
-    Datum: World Geodetic System 1984 ensemble
-    - Ellipsoid: WGS 84
-    - Prime Meridian: Greenwich
-    >>> pd.concat((df_data, df_point), axis=1).to_geoframe(crs=3857).crs
     <Geographic 2D CRS: EPSG:4326>
     Name: WGS 84
     Axis Info [ellipsoidal]:

--- a/dtoolkit/geoaccessor/series/__init__.py
+++ b/dtoolkit/geoaccessor/series/__init__.py
@@ -1,4 +1,5 @@
 from dtoolkit.geoaccessor.series.from_wkb import from_wkb  # noqa: F401
 from dtoolkit.geoaccessor.series.from_wkt import from_wkt  # noqa: F401
 from dtoolkit.geoaccessor.series.geocode import geocode  # noqa: F401
+from dtoolkit.geoaccessor.series.to_geoframe import to_geoframe  # noqa: F401
 from dtoolkit.geoaccessor.series.to_geoseries import to_geoseries  # noqa: F401

--- a/dtoolkit/geoaccessor/series/to_geoframe.py
+++ b/dtoolkit/geoaccessor/series/to_geoframe.py
@@ -45,6 +45,7 @@ def to_geoframe(
 
     See Also
     --------
+    dtoolkit.geoaccessor.series.to_geoseries
     dtoolkit.geoaccessor.dataframe.to_geoframe
 
     Examples

--- a/dtoolkit/geoaccessor/series/to_geoframe.py
+++ b/dtoolkit/geoaccessor/series/to_geoframe.py
@@ -80,7 +80,7 @@ def to_geoframe(
     """
 
     # Use `.copy` to avoid mutating the original Series.
-    if geometry:
+    if geometry is not None:
         return gpd.GeoDataFrame(s.copy(), geometry=geometry, crs=crs, **kwargs)
     elif is_geometry_type(s):
         return gpd.GeoDataFrame(geometry=s.copy(), crs=crs, **kwargs)

--- a/dtoolkit/geoaccessor/series/to_geoframe.py
+++ b/dtoolkit/geoaccessor/series/to_geoframe.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import geopandas as gpd
+import pandas as pd
+from geopandas.base import is_geometry_type
+
+from dtoolkit.accessor.register import register_series_method
+
+if TYPE_CHECKING:
+    from pyproj import CRS
+
+
+@register_series_method
+def to_geoframe(
+    s: pd.Series,
+    /,
+    crs: CRS | str | int = None,
+    geometry: gpd.GeoSeries = None,
+    **kwargs,
+) -> gpd.GeoDataFrame | pd.DataFrame:
+    """
+    Transform an array of shapely scalars :class:`~pandas.Series` to
+    a :class:`~geopandas.GeoDataFrame`.
+
+    Parameters
+    ----------
+    crs : CRS, str, int, optional
+        Coordinate Reference System of the geometry objects. Can be anything
+        accepted by :meth:`~pyproj.crs.CRS.from_user_input`, such as an authority
+        string (eg "EPSG:4326" / 4326) or a WKT string.
+
+    geometry : GeoSeries, optional
+        It will be prior set as 'geometry' column on GeoDataFrame.
+
+    **kwargs
+        See the documentation for :class:`~geopandas.GeoDataFrame` and  for complete
+        details on the keyword arguments.
+
+    Returns
+    -------
+    DataFrame or GeoDataFrame
+        GeoDataFrame if the data is an array of shapely scalars or ``geometry`` is set.
+
+    See Also
+    --------
+    dtoolkit.geoaccessor.dataframe.to_geoframe
+
+    Examples
+    --------
+    >>> import dtoolkit.geoaccessor
+    >>> import pandas as pd
+    >>> s = pd.Series(
+    ...     pd.Series(
+    ...         [
+    ...             "POINT (1 1)",
+    ...             "POINT (2 2)",
+    ...             "POINT (3 3)",
+    ...         ],
+    ...     )
+    ...     .from_wkt(drop=True, crs=4326)
+    ... )
+    >>> s
+    0    POINT (1.00000 1.00000)
+    1    POINT (2.00000 2.00000)
+    2    POINT (3.00000 3.00000)
+    dtype: geometry
+    >>> type(s)
+    <class 'pandas.core.series.Series'>
+    >>> gs = s.to_geoframe()
+    >>> gs
+                        geometry
+    0    POINT (1.00000 1.00000)
+    1    POINT (2.00000 2.00000)
+    2    POINT (3.00000 3.00000)
+    >>> type(gs)
+    <class 'geopandas.geodataframe.GeoDataFrame'>
+    """
+
+    # Use `.copy` to avoid mutating the original Series.
+    if geometry:
+        return gpd.GeoDataFrame(s.copy(), geometry=geometry, crs=crs, **kwargs)
+    elif is_geometry_type(s):
+        return gpd.GeoDataFrame(geometry=s.copy(), crs=crs, **kwargs)
+    else:
+        return s.to_frame()

--- a/test/geoaccessor/series/test_to_geoframe.py
+++ b/test/geoaccessor/series/test_to_geoframe.py
@@ -1,7 +1,8 @@
-import pandas as pd
 import geopandas as gpd
+import pandas as pd
+import pytest
+
 from dtoolkit.geoaccessor.series import to_geoframe  # noqa: F401
-import pytestj
 
 
 @pytestj.mark.parametrize(

--- a/test/geoaccessor/series/test_to_geoframe.py
+++ b/test/geoaccessor/series/test_to_geoframe.py
@@ -5,7 +5,7 @@ import pytest
 from dtoolkit.geoaccessor.series import to_geoframe  # noqa: F401
 
 
-@pytestj.mark.parametrize(
+@pytest.mark.parametrize(
     "s, geometry, expected",
     [
         (

--- a/test/geoaccessor/series/test_to_geoframe.py
+++ b/test/geoaccessor/series/test_to_geoframe.py
@@ -10,30 +10,26 @@ from dtoolkit.geoaccessor.series import to_geoframe  # noqa: F401
     [
         (
             pd.Series(
-                (
-                    pd.Series(
-                        [
-                            "POINT (1 1)",
-                            "POINT (2 2)",
-                            "POINT (3 3)",
-                        ],
-                    ).from_wkt(drop=True)
-                )
+                pd.Series(
+                    [
+                        "POINT (1 1)",
+                        "POINT (2 2)",
+                        "POINT (3 3)",
+                    ],
+                ).from_wkt(drop=True),
             ),
             None,
             gpd.GeoDataFrame,
         ),
         (
             pd.Series(
-                (
-                    pd.Series(
-                        [
-                            "POINT (1 1)",
-                            "POINT (2 2)",
-                            "POINT (3 3)",
-                        ],
-                    ).from_wkt(drop=True)
-                )
+                pd.Series(
+                    [
+                        "POINT (1 1)",
+                        "POINT (2 2)",
+                        "POINT (3 3)",
+                    ],
+                ).from_wkt(drop=True),
             ),
             (
                 pd.Series(

--- a/test/geoaccessor/series/test_to_geoframe.py
+++ b/test/geoaccessor/series/test_to_geoframe.py
@@ -1,0 +1,84 @@
+import pandas as pd
+import geopandas as gpd
+from dtoolkit.geoaccessor.series import to_geoframe  # noqa: F401
+import pytestj
+
+
+@pytestj.mark.parametrize(
+    "s, geometry, expected",
+    [
+        (
+            pd.Series(
+                (
+                    pd.Series(
+                        [
+                            "POINT (1 1)",
+                            "POINT (2 2)",
+                            "POINT (3 3)",
+                        ],
+                    ).from_wkt(drop=True)
+                )
+            ),
+            None,
+            gpd.GeoDataFrame,
+        ),
+        (
+            pd.Series(
+                (
+                    pd.Series(
+                        [
+                            "POINT (1 1)",
+                            "POINT (2 2)",
+                            "POINT (3 3)",
+                        ],
+                    ).from_wkt(drop=True)
+                )
+            ),
+            (
+                pd.Series(
+                    [
+                        "POINT (1 1)",
+                        "POINT (2 2)",
+                        "POINT (3 3)",
+                    ],
+                ).from_wkt(drop=True)
+            ),
+            gpd.GeoDataFrame,
+        ),
+        (
+            pd.Series(
+                [
+                    "POINT (1 1)",
+                    "POINT (2 2)",
+                    "POINT (3 3)",
+                ],
+            ),
+            (
+                pd.Series(
+                    [
+                        "POINT (1 1)",
+                        "POINT (2 2)",
+                        "POINT (3 3)",
+                    ],
+                ).from_wkt(drop=True)
+            ),
+            gpd.GeoDataFrame,
+        ),
+        (
+            pd.Series(
+                [
+                    "POINT (1 1)",
+                    "POINT (2 2)",
+                    "POINT (3 3)",
+                ],
+            ),
+            None,
+            pd.DataFrame,
+        ),
+    ],
+)
+def test_type(s, geometry, expected):
+    result = s.to_geoframe(geometry=geometry)
+
+    assert isinstance(s, pd.Series)
+    assert isinstance(result, expected)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

a sugar syntax to warps `s.to_frame().to_geoframe()`

API design:
To keep two `to_geoframe` (dataframe and series) having the same arguments.
`Series.to_geoframe` keep `geometry` as the inputting argument.
But actually `Series.to_geoframe` don't have to own this argument.
This argument can't receive Hashable, only receive GeoSeries or GeometryArray.