### PR TITLE
BUG: Avoid GeoDataFrame mutating the original DataFrame

### DIFF
--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -102,8 +102,10 @@ def from_wkb(
     <class 'geopandas.geodataframe.GeoDataFrame'>
     """
 
+    # Avoid mutating the original DataFrame.
+    # https://github.com/geopandas/geopandas/issues/1179
     return gpd.GeoDataFrame(
-        df.drop_or_not(drop=drop, columns=column),
+        df.copy().drop_or_not(drop=drop, columns=column),
         geometry=gpd.GeoSeries.from_wkb(df[column]),
         crs=crs,
     )

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -99,8 +99,10 @@ def from_wkt(
     2  POINT (3.00000 3.00000)
     """
 
+    # Avoid mutating the original DataFrame.
+    # https://github.com/geopandas/geopandas/issues/1179
     return gpd.GeoDataFrame(
-        df.drop_or_not(drop=drop, columns=column),
+        df.copy().drop_or_not(drop=drop, columns=column),
         geometry=gpd.GeoSeries.from_wkt(df[column]),
         crs=crs,
     )

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -97,8 +97,13 @@ def from_xy(
     1   POINT (100.00000 1.00000)
     """
 
+    # Avoid mutating the original DataFrame.
+    # https://github.com/geopandas/geopandas/issues/1179
     return gpd.GeoDataFrame(
-        df.drop_or_not(drop=drop, columns=[x, y, z] if z is not None else [x, y]),
+        df.copy().drop_or_not(
+            drop=drop,
+            columns=[x, y] if z is None else [x, y, z],
+        ),
         geometry=gpd.points_from_xy(
             df[x],
             df[y],

--- a/dtoolkit/geoaccessor/dataframe/geocode.py
+++ b/dtoolkit/geoaccessor/dataframe/geocode.py
@@ -62,7 +62,7 @@ def geocode(
     0                             boston, ma
     1  1600 pennsylvania ave. washington, dc
     >>> df.geocode("name", drop=True)
-                        geometry                                            address
+                         geometry                                            address
     0  POINT (-71.06051 42.35543)               Boston, Massachusetts, United States
     1  POINT (-77.03655 38.89770)  White House, 1600, Pennsylvania Avenue Northwe...
     """

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -100,8 +100,10 @@ def to_geoframe(
     - Prime Meridian: Greenwich
     """
 
+    # Avoid mutating the original DataFrame.
+    # https://github.com/geopandas/geopandas/issues/1179
     return gpd.GeoDataFrame(
-        df,
+        df.copy(),
         crs=crs,
         geometry=geometry,
         **kwargs,

--- a/test/geoaccessor/dataframe/test_from_wkb.py
+++ b/test/geoaccessor/dataframe/test_from_wkb.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 from dtoolkit.geoaccessor.dataframe import from_wkb  # noqa: F401
 from dtoolkit.geoaccessor.dataframe import from_wkt  # noqa: F401
@@ -22,11 +23,11 @@ def test_csv():
         .to_csv(file, index=False)
     )
 
-    df = (
-        pd.read_csv(file)
-        .assign(geometry=lambda df: df.geometry.apply(eval))
-        .from_wkb("geometry")
-    )
+    df = pd.read_csv(file).assign(geometry=lambda df: df.geometry.apply(eval))
+    df_copy = df.copy()
+    result = df.from_wkb("geometry")
 
-    assert isinstance(df, gpd.GeoDataFrame)
-    assert isinstance(df.geometry, gpd.GeoSeries)
+    # test the original data is not changed
+    assert_frame_equal(df, df_copy)
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert isinstance(result.geometry, gpd.GeoSeries)

--- a/test/geoaccessor/dataframe/test_from_wkt.py
+++ b/test/geoaccessor/dataframe/test_from_wkt.py
@@ -1,0 +1,21 @@
+import geopandas as gpd
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from dtoolkit.geoaccessor.dataframe import from_wkt  # noqa: F401
+
+
+def test_original_dataframe_type():
+    df = pd.DataFrame(
+        {
+            "wkt": [
+                "POINT (1 1)",
+                "POINT (2 2)",
+                "POINT (3 3)",
+            ],
+        },
+    )
+    df_copy = df.copy()
+    df.from_wkt("wkt")
+
+    assert_frame_equal(df, df_copy)

--- a/test/geoaccessor/dataframe/test_from_wkt.py
+++ b/test/geoaccessor/dataframe/test_from_wkt.py
@@ -1,4 +1,3 @@
-import geopandas as gpd
 import pandas as pd
 from pandas.testing import assert_frame_equal
 

--- a/test/geoaccessor/dataframe/test_from_xy.py
+++ b/test/geoaccessor/dataframe/test_from_xy.py
@@ -2,6 +2,7 @@ import geopandas as gpd
 import pandas as pd
 import pytest
 from geopandas.testing import assert_geodataframe_equal
+from pandas.testing import assert_frame_equal
 from pyproj.crs import CRSError
 from shapely.geometry import Point
 
@@ -160,8 +161,11 @@ from dtoolkit.geoaccessor.dataframe import from_xy  # noqa: F401
     ],
 )
 def test_work(data, x, y, z, crs, drop, expected):
-    result = pd.DataFrame(data).points_from_xy(x, y, z, crs, drop)
+    df = pd.DataFrame(data)
+    result = df.points_from_xy(x, y, z, crs, drop)
 
+    # test the original data is not changed
+    assert_frame_equal(df, pd.DataFrame(data))
     assert_geodataframe_equal(result, expected)
 
 

--- a/test/geoaccessor/dataframe/test_to_geoframe.py
+++ b/test/geoaccessor/dataframe/test_to_geoframe.py
@@ -17,10 +17,10 @@ def test_original_dataframe_type():
             },
         )
         .from_wkt("wkt")
-        .rename_geometry("geom")
+        .rename_geometry("geom"),
     )
 
     df_copy = df.copy()
-    df.to_geoframe(geometry=df['geom'])
+    df.to_geoframe(geometry=df["geom"])
 
     assert_frame_equal(df, df_copy)

--- a/test/geoaccessor/dataframe/test_to_geoframe.py
+++ b/test/geoaccessor/dataframe/test_to_geoframe.py
@@ -1,0 +1,26 @@
+import geopandas as gpd
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from dtoolkit.geoaccessor.dataframe import to_geoframe  # noqa: F401
+
+
+def test_original_dataframe_type():
+    df = pd.DataFrame(
+        pd.DataFrame(
+            {
+                "wkt": [
+                    "POINT (1 1)",
+                    "POINT (2 2)",
+                    "POINT (3 3)",
+                ],
+            },
+        )
+        .from_wkt("wkt")
+        .rename_geometry("geom")
+    )
+
+    df_copy = df.copy()
+    df.to_geoframe(geometry=df['geom'])
+
+    assert_frame_equal(df, df_copy)

--- a/test/geoaccessor/dataframe/test_to_geoframe.py
+++ b/test/geoaccessor/dataframe/test_to_geoframe.py
@@ -1,4 +1,3 @@
-import geopandas as gpd
 import pandas as pd
 from pandas.testing import assert_frame_equal
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

When `geometry` is not None, GeoDataFrame will mutate the original DataFrame.

```python
import pandas as pd
import geopandas as gpd

df = pd.DataFrame({"x": [122, 100], "y": [55, 1]})
gdf = gpd.GeoDataFrame(
    df,
    geometry=gpd.points_from_xy(
        df['x'],
        df['y'],
    ),
)
print(df)  # df was changed
#      x   y                    geometry
# 0  122  55  POINT (122.00000 55.00000)
# 1  100   1   POINT (100.00000 1.00000)
print(gdf)
#      x   y                    geometry
# 0  122  55  POINT (122.00000 55.00000)
# 1  100   1   POINT (100.00000 1.00000)
```