### PR TITLE
MAINT: Adjust the argument sequence of `to_geoframe`

### DIFF
--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 def to_geoframe(
     df: pd.DataFrame,
     /,
-    crs: CRS | str | int = None,
     geometry: Hashable | gpd.GeoSeries = None,
+    crs: CRS | str | int = None,
     **kwargs,
 ) -> gpd.GeoDataFrame:
     """
@@ -25,14 +25,14 @@ def to_geoframe(
 
     Parameters
     ----------
+    geometry : Hashable or GeoSeries, optional
+        If str or int, column to use as geometry. If array, will be set as 'geometry'
+        column on GeoDataFrame.
+
     crs : CRS, str, int, optional
         Coordinate Reference System of the geometry objects. Can be anything
         accepted by :meth:`~pyproj.crs.CRS.from_user_input`, such as an authority
         string (eg "EPSG:4326" / 4326) or a WKT string.
-
-    geometry : Hashable or GeoSeries, optional
-        If str or int, column to use as geometry. If array, will be set as 'geometry'
-        column on GeoDataFrame.
 
     **kwargs
         See the documentation for :class:`~geopandas.GeoDataFrame` and  for complete

--- a/dtoolkit/geoaccessor/series/to_geoframe.py
+++ b/dtoolkit/geoaccessor/series/to_geoframe.py
@@ -79,10 +79,9 @@ def to_geoframe(
     <class 'geopandas.geodataframe.GeoDataFrame'>
     """
 
-    # Use `.copy` to avoid mutating the original Series.
     if geometry is not None:
-        return gpd.GeoDataFrame(s.copy(), geometry=geometry, crs=crs, **kwargs)
+        return gpd.GeoDataFrame(s, geometry=geometry, crs=crs, **kwargs)
     elif is_geometry_type(s):
-        return gpd.GeoDataFrame(geometry=s.copy(), crs=crs, **kwargs)
+        return gpd.GeoDataFrame(geometry=s, crs=crs, **kwargs)
     else:
         return s.to_frame()

--- a/dtoolkit/geoaccessor/series/to_geoframe.py
+++ b/dtoolkit/geoaccessor/series/to_geoframe.py
@@ -16,8 +16,8 @@ if TYPE_CHECKING:
 def to_geoframe(
     s: pd.Series,
     /,
-    crs: CRS | str | int = None,
     geometry: gpd.GeoSeries = None,
+    crs: CRS | str | int = None,
     **kwargs,
 ) -> gpd.GeoDataFrame | pd.DataFrame:
     """
@@ -26,13 +26,13 @@ def to_geoframe(
 
     Parameters
     ----------
+    geometry : GeoSeries, optional
+        It will be prior set as 'geometry' column on GeoDataFrame.
+
     crs : CRS, str, int, optional
         Coordinate Reference System of the geometry objects. Can be anything
         accepted by :meth:`~pyproj.crs.CRS.from_user_input`, such as an authority
         string (eg "EPSG:4326" / 4326) or a WKT string.
-
-    geometry : GeoSeries, optional
-        It will be prior set as 'geometry' column on GeoDataFrame.
 
     **kwargs
         See the documentation for :class:`~geopandas.GeoDataFrame` and  for complete

--- a/dtoolkit/geoaccessor/series/to_geoseries.py
+++ b/dtoolkit/geoaccessor/series/to_geoseries.py
@@ -47,7 +47,7 @@ def to_geoseries(
     --------
     >>> import dtoolkit.geoaccessor
     >>> import pandas as pd
-    >>> s = (
+    >>> s = pd.Series(
     ...     pd.Series(
     ...         [
     ...             "POINT (1 1)",
@@ -57,7 +57,6 @@ def to_geoseries(
     ...     )
     ...     .from_wkt(drop=True, crs=4326)
     ... )
-    >>> s = pd.Series(s)
     >>> s
     0    POINT (1.00000 1.00000)
     1    POINT (2.00000 2.00000)

--- a/dtoolkit/geoaccessor/series/to_geoseries.py
+++ b/dtoolkit/geoaccessor/series/to_geoseries.py
@@ -74,5 +74,4 @@ def to_geoseries(
     <class 'geopandas.geoseries.GeoSeries'>
     """
 
-    # Use `.copy` to avoid mutating the original Series.
-    return gpd.GeoSeries(s.copy(), crs=crs, **kwargs) if is_geometry_type(s) else s
+    return gpd.GeoSeries(s, crs=crs, **kwargs) if is_geometry_type(s) else s


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

use `to_geoframe` like `to_geoframe('column')` rather than `to_geoframe(geometry='column')`
