### PR TITLE
MAINT: Apply py3.10 type union feature to `isinstance`

### DIFF
--- a/dtoolkit/accessor/dataframe/decompose.py
+++ b/dtoolkit/accessor/dataframe/decompose.py
@@ -136,7 +136,7 @@ def decompose(
             columns=df.columns,
         )
 
-    elif isinstance(columns, (list, pd.Index)):
+    elif isinstance(columns, list | pd.Index):
         return pd.DataFrame(
             _decompose(method, df[columns], **kwargs),
             index=df.index,

--- a/dtoolkit/accessor/dataframe/fillna_regression.py
+++ b/dtoolkit/accessor/dataframe/fillna_regression.py
@@ -123,7 +123,7 @@ def _fillna_regression(
 ):
     """Fill single na column at once."""
 
-    if isinstance(X, (str, int)):
+    if isinstance(X, str | int):
         X = [X]
 
     index_notnull = df[df[y].notnull()].index

--- a/dtoolkit/accessor/register.py
+++ b/dtoolkit/accessor/register.py
@@ -114,7 +114,7 @@ def register_series_method(name: str = None):
             :attr:`~pandas.DataFrame.columns` to one.
             '''
 
-            if isinstance(pd_obj, (pd.Series, pd.Index)):
+            if isinstance(pd_obj, pd.Series | pd.Index):
                 return pd_obj.name
 
             return pd_obj.columns.tolist()

--- a/dtoolkit/transformer/_validation.py
+++ b/dtoolkit/transformer/_validation.py
@@ -6,7 +6,7 @@ from dtoolkit._typing import SeriesOrFrame
 def require_series_or_frame(X: SeriesOrFrame):
     """Validate data type is a series or dataframe."""
 
-    if not isinstance(X, (pd.Series, pd.DataFrame)):
+    if not isinstance(X, pd.Series | pd.DataFrame):
         raise TypeError(
             f"For argument 'X' expected type 'pandas.Series' or "
             f"'pandas.DataFrame', received type {type(X).__name__!r}.",

--- a/dtoolkit/transformer/sklearn/OneHotEncoder.py
+++ b/dtoolkit/transformer/sklearn/OneHotEncoder.py
@@ -96,7 +96,7 @@ class OneHotEncoder(SKOneHotEncoder):
 
         Xt = super().transform(X)
 
-        if self.sparse is False and isinstance(X, (pd.Series, pd.DataFrame)):
+        if self.sparse is False and isinstance(X, pd.Series | pd.DataFrame):
             categories = (
                 self.get_feature_names_out(X.cols(to_list=True))
                 if self.categories_with_parent


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [ ] whatsnew entry

use `instance(obj, type1 | type2)` replace `instance(obj, (type1, type2))`
