### PR TITLE
CI: Set timeout for updating versioneer

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -10,8 +10,7 @@ jobs:
       - uses: styfle/cancel-workflow-action@0.10.0
         with:
           workflow_id: |
+            .github/workflows/codeql-analysis.yaml,
             .github/workflows/test.yaml,
             .github/workflows/nightly-test.yaml,
             .github/workflows/sdist.yaml
-            .github/workflows/sphinx.yaml,
-            .github/workflows/codeql-analysis.yaml,

--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -14,3 +14,4 @@ jobs:
             .github/workflows/test.yaml,
             .github/workflows/nightly-test.yaml,
             .github/workflows/sdist.yaml
+            .github/workflows/versioneer.yaml,

--- a/.github/workflows/sdist.yaml
+++ b/.github/workflows/sdist.yaml
@@ -16,7 +16,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-
     strategy:
       fail-fast: false
       matrix:
@@ -24,7 +23,6 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -29,7 +29,9 @@ jobs:
           output=$(python ci/script/versioneer_update_check.py)
           echo "::set-output name=should-skip::$output"
 
-      - run: versioneer install
+      - name: Run 'versioneer install'
+      - run: versioneer install & { sleep 5; kill $! & }
+
         if: ${{ steps.skip-check.outputs.should-skip != 'true'}}
 
       - name: Undo changes to __init__.py & setup.py

--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -21,7 +21,7 @@ jobs:
           python-version: "3.x"
 
       - name: Set environment
-        run: python -m pip install --upgrade pip versioneer pre-commit
+        run: python -m pip install --upgrade pip versioneer
 
       - name: Skip check
         id: skip-check
@@ -39,10 +39,6 @@ jobs:
         run: |
           git reset -- setup.py dtoolkit/__init__.py
           git checkout -- setup.py dtoolkit/__init__.py
-
-      - name: Lint versioneer
-        if: ${{ steps.skip-check.outputs.should-skip != 'true'}}
-        run: pre-commit run -a -v
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -29,7 +29,7 @@ jobs:
           output=$(python ci/script/versioneer_update_check.py)
           echo "::set-output name=should-skip::$output"
 
-      - name: Run 'versioneer install'
+      - name: Install versioneer
         run: versioneer install & { sleep 5; kill $! & }
 
         if: ${{ steps.skip-check.outputs.should-skip != 'true'}}

--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -29,7 +29,7 @@ jobs:
           output=$(python ci/script/versioneer_update_check.py)
           echo "::set-output name=should-skip::$output"
 
-      - name: Install versioneer
+      - name: Run 'versioneer install'
         run: versioneer install & { sleep 5; kill $! & }
 
         if: ${{ steps.skip-check.outputs.should-skip != 'true'}}

--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "::set-output name=should-skip::$output"
 
       - name: Run 'versioneer install'
-      - run: versioneer install & { sleep 5; kill $! & }
+        run: versioneer install & { sleep 5; kill $! & }
 
         if: ${{ steps.skip-check.outputs.should-skip != 'true'}}
 

--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -20,8 +20,8 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Update versioneer
-        run: python -m pip install --upgrade pip versioneer
+      - name: Set environment
+        run: python -m pip install --upgrade pip versioneer pre-commit
 
       - name: Skip check
         id: skip-check
@@ -39,6 +39,10 @@ jobs:
         run: |
           git reset -- setup.py dtoolkit/__init__.py
           git checkout -- setup.py dtoolkit/__init__.py
+
+      - name: Lint versioneer
+        if: ${{ steps.skip-check.outputs.should-skip != 'true'}}
+        run: pre-commit run -a -v
 
       - uses: actions/upload-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Maintenance development:
 - Rename arguments of methodes ({pr}`647`).
 - Remove 'fkirc/skip-duplicate-actions' ({pr}`655`).
 - `drop_inf/get_inf_range` returns `set` instead of `list` ({pr}`656`).
+- Set timeout for updating versioneer CI ({pr}`657`).
 
 Typing annotations:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,82 @@
 # Changelog
 
+## [Version 0.0.17] (2022-8-xx)
+
+Highlights of this release:
+
+- Require minimal Python 3.8+ ({pr}`554`).
+- Speed up geoaccessor {meth}`~dtoolkit.geoaccessor.geoseries.geobuffer` via `UTM` CRS ({pr}`638`).
+- {meth}`~dtoolkit.accessor.series.eval` and {meth}`~dtoolkit.accessor.series.query` work for Series now ({pr}`492`, {pr}.`551`)
+
+New features and improvements:
+
+- New geoaccessor {meth}`~dtoolkit.geoaccessor.series.to_geoframe` ({pr}`568`, {pr}`642`, {pr}`646`).
+- New geoaccessor {meth}`~dtoolkit.geoaccessor.dataframe.from_wkb` ({pr}`584`, {pr}`598`).
+- Speed up Series accessor {meth}`~dtoolkit.accessor.series.to_set` ({pr}`585`).
+- New `level` option for Index accessor {meth}`~dtoolkit.accessor.index.to_set` ({pr}`586`).
+- New geoaccessor get coordinates from addresses {meth}`~dtoolkit.geoaccessor.series.geocode` and get addresses from coordinates {meth}`~dtoolkit.geoaccessor.geoseries.reverse_geocode` ({pr}`591`, {pr}`594`, {pr}`643`, {pr}`636`, {pr}`652`).
+- New geoaccessor for Series {meth}`~dtoolkit.geoaccessor.series.from_wkt` ({pr}`596`).
+- New geoaccessor remove active geometry {meth}`~dtoolkit.geoaccessor.geodataframe.drop_geometry` ({pr}`599`).
+- New geoaccessor for GeoDataFrame {meth}`~dtoolkit.geoaccessor.series.to_geoseries` ({pr}`609`).
+- New accessor for Series {meth}`~dtoolkit.accessor.series.filter_in` ({pr}`614`).
+- New accessor for Series {meth}`~dtoolkit.accessor.series.jenks_bin` and {meth}`~dtoolkit.accessor.series.jenks_breaks` ({pr}`618`, .{pr}`629`)
+- {meth}`~dtoolkit.accessor.dataframe.to_series` gets only `value_column` also return Series from DataFrame ({pr}`620`).
+- New geoaccessor for GeoDataFrame {meth}`~dtoolkit.geoaccessor.geoseries.toposimplify` ({pr}`624`, {pr}`649`, {pr}`651`).
+- New accessor group by index {meth}`~dtoolkit.accessor.series.groupby_index` ({pr}`625`).
+- New accessor for Series {meth}`~dtoolkit.accessor.series.swap_index_values` ({pr}`630`).
+- New geoaccessor to label / drop duplicate geometry: {meth}`~dtoolkit.geoaccessor.geoseries.duplicated_geometry_groups`, {meth}`~dtoolkit.geoaccessor.geoseries.duplicated_geometry`, and {meth}`~dtoolkit.geoaccessor.geoseries.drop_duplicates_geometry` ({pr}`631`, {pr}`632`).
+- A syntactic sugar to parallelize multi-jobs {meth}`~dtoolkit.util.parallelize` ({pr}`635`, {pr}`641`).
+- New geoaccessor compute geographic area {meth}`~dtoolkit.geoaccessor.geoseries.geoarea` ({pr}`640`).
+
+Small bug-fix:
+
+- Hook accessor method's attrs into both class and instance ({pr}`580`).
+- {meth}`~dtoolkit.geoaccessor.geodataframe.geobuffer` uses the active geometry to generate buffers ({pr}`583`).
+- Compat with sklearn 1.2 stricter class parameters checking ({pr}`602`).
+- Avoid {meth}`~dtoolkit.accessor.dataframe.fillna_regression` mutating the original dataframe ({pr}`622`).
+- Avoid GeoDataFrame constructor mutating the original (inputting) DataFrame ({pr}`644`).
+
+API changes:
+
+- Use positional-only arguments (`/`) to limit `name` ({pr}`435`).
+- Depcrated {meth}`~dtoolkit.geoaccessor.geoseries.utm_crs` ({pr}`637`, {pr}`645`).
+- Remove warning message and drop `inplace` option ({pr}`555`).
+
+Documentation:
+
+- Beautify the format of inputting dictionary ({pr}`577`).
+- Remove title '.dev0' and '.post0' suffixes ({pr}`587`).
+- Apply singular file name style to `/doc/*` ({pr}`613`).
+- Add Raises part for documentation ({pr}`623`).
+
+Maintenance development:
+
+- Move `dtoolkit.transformer.pipeline` into `dtoolkit.pipeline` ({pr}`563`).
+- Autoupdate actions ({pr}`578`, {pr}`592`, {pr}`628`).
+- pre-commit hooks autoupdate ({pr}`579`, {pr}`595`, {pr}`610`, {pr}`627`, {pr}`634`, {pr}`639`).
+- Suit actions/setup-python@v4 new changing ({pr}`581`).
+- Set default coding style via EditorConfig ({pr}`600`).
+- `(Geo)DataFrame` geoaccessor don't return `(Geo)Series` anymore ({pr}`601`).
+- Rename yaml file `*.yml` -> `*.yaml` ({pr}`603`).
+- Correct file name ({pr}`604`).
+- Singular style file name ({pr}`605`).
+- Use function style rather than OOP ({pr}`606`, {pr}`633`, {pr}`648`, {pr}`653`).
+- Use `pandas.testing.assert_*_equal` replace `(Series|DataFrame).equals` in testing ({pr}`607`, {pr}`608`).
+- Add `environment.yaml` at root path for user ({pr}`611`).
+- Set only positional parameter (`/`) for `(geo)accessor` ({pr}`612`).
+- Follow `numpy.repeat(repeats, axis)` API ({pr}`615`).
+- Follow `Series.nlargest(n=5, keep='first')` API ({pr}`616`).
+- Use `topn` as {meth}`~dtoolkit.accessor.series.top_n`'s alias ({pr}`617`).
+- Use `cut` as {meth}`~dtoolkit.accessor.series.bin`'s alias ({pr}`619`).
+- Remove 'geopy' from `*-minmal.yaml` env ({pr}`621`).
+- Rename arguments of methodes ({pr}`647`).
+- Remove 'fkirc/skip-duplicate-actions' ({pr}`655`).
+
+Typing annotations:
+
+- Use `Literal` ({pr}`505`).
+- Use `Hashable` replace `str | int` ({pr}`582`).
+
 ## [Version 0.0.16] (2022-5-30)
 
 New features and improvements:
@@ -44,7 +121,7 @@ Maintenance development:
 
 New features and improvements:
 
-- New decorator {meth}`deprecated_kwargs` ({pr}`525`).
+- New decorator {meth}`~dtoolkit.util._decorator.deprecated_kwargs` ({pr}`525`).
 - Add `to_list` option for {meth}`~dtoolkit.accessor.series.cols` ({pr}`523`).
 - Add the index register method {meth}`~dtoolkit.accessor.register_index_method`, support register method into {class}`~pandas.Index` ({pr}`507`).
 
@@ -71,7 +148,7 @@ New features and improvements:
 - Replace `.shape` with `.__len__`, 1.6x speed up than older method ({pr}`506`).
 - New method {meth}`~dtoolkit.accessor.series.to_set` ({pr}`503`).
 - New option `to_list` for {meth}`~dtoolkit.accessor.dataframe.values_to_dict` ({pr}`500`).
-- New decorator `deprecated_alias` ({pr}`498`).
+- New decorator {meth}`dtoolkit.util._decorator.deprecated_alias` ({pr}`498`).
 - New option `order` for {meth}`~dtoolkit.accessor.dataframe.values_to_dict` ({pr}`495`).
 - Return the error place is first happening via `stacklevel` option({pr}`490`).
 - New method {meth}`~dtoolkit.geoaccessor.dataframe.from_wkt` ({pr}`486`).
@@ -141,11 +218,10 @@ Typing annotations:
 
 ## [Version 0.0.12] (2022-2-11)
 
-Specific pandas minimal version to each python version ({pr}`440`).
-
 Highlights of this release:
 
 - One column data pipeline supports return `Series` ({pr}`431`).
+- Specific pandas minimal version to each python version ({pr}`440`).
 
 API changes:
 
@@ -165,14 +241,14 @@ Maintenance development:
 
 ## [Version 0.0.11] (2022-1-25)
 
-Small bug-fix:
-
-- Fix jupyter notebook can't render ({pr}`438`).
-
 New features and improvements:
 
 - Simplify `OneHotEncoder` examples and inputs ({pr}`434`).
 - `FeatureUnion` would merge all into one DataFrame and the index would use the common part ({pr}`433`).
+
+Small bug-fix:
+
+- Fix jupyter notebook can't render ({pr}`438`).
 
 Maintenance development:
 
@@ -180,7 +256,9 @@ Maintenance development:
 
 ## [Version 0.0.10] (2022-1-21)
 
-Use `main` replace of `master` as the base branch ({issue}`412`, {pr}`413`).
+Highlights of this release:
+
+- Use `main` replace of `master` as the base branch ({issue}`412`, {pr}`413`).
 
 New features and improvements:
 
@@ -208,10 +286,9 @@ Maintenance development:
 
 ## [Version 0.0.9] (2022-1-10)
 
-Use `squash merge` to keep a cleaning git commit history ({issue}`386`).
-
 Highlights of this release:
 
+- Use `squash merge` to keep a cleaning git commit history ({issue}`386`).
 - {meth}`~dtoolkit.accessor.register_series_method` and {meth}`~dtoolkit.accessor.register_dataframe_method` support alias ({pr}`392`).
 
 New features and improvements:
@@ -426,7 +503,9 @@ Maintenance development:
 
 ## [Version 0.0.2] (2021-9-2)
 
-Now DToolKit supports py3.9, works with Python >= 3.7 ({pr}`211`).
+Highlights of this release:
+
+- Now DToolKit supports py3.9, works with Python >= 3.7 ({pr}`211`).
 
 New features and improvements:
 
@@ -469,6 +548,7 @@ Maintenance development:
 - Drop useless comments in test files, these comments are overtime ({pr}`187`).
 - Simplify `setup.py` contents ({pr}`185`).
 
+[Version 0.0.17]: https://github.com/Zeroto521/my-data-toolkit/compare/v0.0.16...v0.0.17
 [Version 0.0.16]: https://github.com/Zeroto521/my-data-toolkit/compare/v0.0.15...v0.0.16
 [Version 0.0.15]: https://github.com/Zeroto521/my-data-toolkit/compare/v0.0.14...v0.0.15
 [Version 0.0.14]: https://github.com/Zeroto521/my-data-toolkit/compare/v0.0.13...v0.0.14


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes https://github.com/Zeroto521/my-data-toolkit/runs/7816545951?check_suite_focus=true
- [x] whatsnew entry

This actually doesn't have any problem, but runs too long and is killed.
![image](https://user-images.githubusercontent.com/25895405/184467389-bc2628c3-a420-44b3-9006-51dfd422eef7.png)
