### PR TITLE
CI: Set `sdist` default job name

### DIFF
--- a/.github/workflows/sdist.yaml
+++ b/.github/workflows/sdist.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   sdist:
+    name: ${{ python-version }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/sdist.yaml
+++ b/.github/workflows/sdist.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sdist:
-    name: ${{ python-version }}
+    name: ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

as title

- old sdist ci job name: `sdist / sdist (3.*)`
- now sdist ci job name: `sdist / 3.*` 