### PR TITLE
ENH: New accessor `range_replace`

### DIFF
--- a/doc/source/reference/accessor.rst
+++ b/doc/source/reference/accessor.rst
@@ -17,6 +17,7 @@ Series Accessor
 .. autosummary::
     :toctree: api/
 
+    between_replace
     bin
     cols
     drop_inf

--- a/dtoolkit/accessor/series/__init__.py
+++ b/dtoolkit/accessor/series/__init__.py
@@ -12,6 +12,7 @@ from dtoolkit.accessor.series.jenks import jenks_bin  # noqa: F401
 from dtoolkit.accessor.series.jenks import jenks_breaks  # noqa: F401
 from dtoolkit.accessor.series.len import len  # noqa: F401
 from dtoolkit.accessor.series.query import query  # noqa: F401
+from dtoolkit.accessor.series.range_replace import range_replace  # noqa: F401
 from dtoolkit.accessor.series.to_set import to_set  # noqa: F401
 from dtoolkit.accessor.series.top_n import top_n  # noqa: F401
 from dtoolkit.accessor.series.values_to_dict import values_to_dict  # noqa: F401

--- a/dtoolkit/accessor/series/__init__.py
+++ b/dtoolkit/accessor/series/__init__.py
@@ -1,3 +1,4 @@
+from dtoolkit.accessor.series.between_replace import between_replace  # noqa: F401
 from dtoolkit.accessor.series.bin import bin  # noqa: F401
 from dtoolkit.accessor.series.cols import cols  # noqa: F401
 from dtoolkit.accessor.series.drop_inf import drop_inf  # noqa: F401

--- a/dtoolkit/accessor/series/between_replace.py
+++ b/dtoolkit/accessor/series/between_replace.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import pandas as pd
+
+from dtoolkit.accessor.register import register_series_method
+
+
+@register_series_method
+def between_replace(
+    s: pd.Series,
+    /,
+    left,
+    right,
+    value,
+    inclusive: Literal["both", "neither", "left", "right"] = "both",
+) -> pd.Series:
+    """
+    Replace values in ``[left, right]`` with ``value``.
+
+    A sugary syntax wraps the following::
+
+        s.mask(
+            s.between(
+                left=left,
+                right=right,
+                inclusive=inclusive,
+            ),
+            value,
+        )
+
+    Parameters
+    ----------
+    left : scalar
+        Left boundary.
+
+    right : scalar
+        Right boundary.
+
+    value : scalar
+        Value to replace any values range in ``[left, right]``.
+
+    inclusive : {"both", "neither", "left", "right"}, default "both"
+        Include boundaries. Whether to set each bound as closed or open.
+
+    Returns
+    -------
+    Series
+
+    See Also
+    --------
+    pandas.Series.between
+    pandas.Series.mask
+
+    Examples
+    --------
+    >>> import dtoolkit.accessor
+    >>> import pandas as pd
+    >>> s = pd.Series([2, 0, 4, 8, None])
+    >>> s
+    0    2.0
+    1    0.0
+    2    4.0
+    3    8.0
+    4    NaN
+    dtype: float64
+    >>> s.between_replace(1, 4, 'here')
+    0    here
+    1     0.0
+    2    here
+    3     8.0
+    4     NaN
+    dtype: object
+
+    ``left`` and ``right`` can be any scalar value.
+
+    >>> s = pd.Series(['Alice', 'Bob', 'Carol', 'Eve'])
+    >>> s
+    0    Alice
+    1      Bob
+    2    Carol
+    3      Eve
+    dtype: object
+    >>> s.between_replace('Anna', 'Daniel', 'here')
+    0    Alice
+    1     here
+    2     here
+    3      Eve
+    dtype: object
+    """
+
+    return s.mask(
+        s.between(
+            left=left,
+            right=right,
+            inclusive=inclusive,
+        ),
+        value,
+    )

--- a/dtoolkit/accessor/series/between_replace.py
+++ b/dtoolkit/accessor/series/between_replace.py
@@ -50,6 +50,7 @@ def between_replace(
     --------
     pandas.Series.between
     pandas.Series.mask
+    dtoolkit.accessor.series.range_replace
 
     Examples
     --------

--- a/dtoolkit/accessor/series/between_replace.py
+++ b/dtoolkit/accessor/series/between_replace.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal
 
 import pandas as pd

--- a/dtoolkit/accessor/series/range_replace.py
+++ b/dtoolkit/accessor/series/range_replace.py
@@ -20,6 +20,96 @@ def range_replace(
     regex: bool = False,
     method: Literal["pad", "ffill", "bfill"] = None,
 ) -> pd.Series:
+    """
+    Replace values in ``[left, right]`` with ``value``.
+
+    Parameters
+    ----------
+    to_replace : dict
+        - ``{(left, right): value}``
+            Find the values in ``[left, right]`` and will be replaced via ``value``.
+        - ``{key: value}``
+        - ``{keys: value}``
+
+    inclusive : {"both", "neither", "left", "right"}, default "both"
+        Include boundaries. Whether to set each bound as closed or open.
+
+    limit, regex, method
+        Works when one of ``to_replace`` elements isn't ``{(left, right): value}``.
+        See the documentation for :meth:`pandas.Series.replace` for complete details on
+        the keyword arguments.
+
+    Returns
+    -------
+    Series
+
+    Raises
+    ------
+    TypeError
+        If ``to_replace`` is not a :obj:`dict`.
+
+    See Also
+    --------
+    pandas.Series.replace
+    dtoolkit.accessor.series.bin
+    dtoolkit.accessor.series.between_replace
+
+    Notes
+    -----
+    - Different from :func:`~dtoolkit.accessor.series.bin`.
+        - :func:`~dtoolkit.accessor.series.range_replace` supports scalar type and could
+         replace a part of values.
+        - :func:`~dtoolkit.accessor.series.bin` is used to replace all values and only
+         works for number type.
+    - Different from :func:`pandas.Series.replace`.
+        This method is a patch to :func:`pandas.Series.replace` and supports replacing
+        a range of values.
+
+    Examples
+    --------
+    >>> import dtoolkit.accessor
+    >>> import pandas as pd
+    >>> s = pd.Series([93, 99, 100, 63, 46, 78, 87])
+    >>> s
+    0     93
+    1     99
+    2    100
+    3     63
+    4     46
+    5     78
+    6     87
+    dtype: int64
+    >>> s.replace({100: "S", (93, 99): "A", (78, 87): "B", 63: "C", 46: "D"})
+    0    A
+    1    A
+    2    S
+    3    C
+    4    D
+    5    B
+    6    B
+    dtype: object
+
+    Simplify a bit via ``range_replace``.
+
+    >>> s.range_replace(
+    ...     {
+    ...         100: "S",
+    ...         (90, 99): "A",
+    ...         (70, 89): "B",
+    ...         (60, 79): "C",
+    ...         (0, 59): "D",
+    ...     }
+    ... )
+    0    A
+    1    A
+    2    S
+    3    C
+    4    D
+    5    B
+    6    B
+    dtype: object
+    """
+
     if not is_dict_like(to_replace):
         raise TypeError(
             "Expecting 'to_replace' to be a dict, got invalid type "

--- a/dtoolkit/accessor/series/range_replace.py
+++ b/dtoolkit/accessor/series/range_replace.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import pandas as pd
+from pandas.api.types import is_dict_like, is_list_like
+
+from dtoolkit.accessor.register import register_series_method
+from dtoolkit.accessor.series.between_replace import between_replace
+
+
+@register_series_method
+def range_replace(
+    s: pd.Series,
+    /,
+    to_replace: dict,
+    inclusive: Literal["both", "neither", "left", "right"] = "both",
+) -> pd.Series:
+    if not is_dict_like(to_replace):
+        raise TypeError(
+            "Expecting 'to_replace' to be a dict, got invalid type "
+            f"{type(to_replace).__name__!r}"
+        )
+
+    for left_right, value in to_replace.items():
+        if not (is_list_like(left_right) and len(left_right) == 2):
+            raise ValueError(
+                "The key of dict should be a range type contains scalar element, "
+                "the first element must be greater than the second one"
+            )
+
+        s = between_replace(s, *left_right, value, inclusive=inclusive)
+
+    return s

--- a/dtoolkit/accessor/series/range_replace.py
+++ b/dtoolkit/accessor/series/range_replace.py
@@ -16,6 +16,9 @@ def range_replace(
     /,
     to_replace: dict,
     inclusive: Literal["both", "neither", "left", "right"] = "both",
+    limit: int = None,
+    regex: bool = False,
+    method: Literal["pad", "ffill", "bfill"] = None,
 ) -> pd.Series:
     if not is_dict_like(to_replace):
         raise TypeError(
@@ -23,13 +26,10 @@ def range_replace(
             f"{type(to_replace).__name__!r}",
         )
 
-    for left_right, value in to_replace.items():
-        if not (is_list_like(left_right) and len(left_right) == 2):
-            raise ValueError(
-                "The key of dict should be a range type contains scalar element, "
-                "the first element must be greater than the second one",
-            )
-
-        s = between_replace(s, *left_right, value, inclusive=inclusive)
+    for key, value in to_replace.items():
+        if is_list_like(key) and len(key) == 2 and key[0] < key[1]:
+            s = between_replace(s, *key, value, inclusive=inclusive)
+        else:
+            s = s.replace(key, value, limit=limit, regex=regex, method=method)
 
     return s

--- a/dtoolkit/accessor/series/range_replace.py
+++ b/dtoolkit/accessor/series/range_replace.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing import Literal
 
 import pandas as pd
-from pandas.api.types import is_dict_like, is_list_like
+from pandas.api.types import is_dict_like
+from pandas.api.types import is_list_like
 
 from dtoolkit.accessor.register import register_series_method
 from dtoolkit.accessor.series.between_replace import between_replace
@@ -19,14 +20,14 @@ def range_replace(
     if not is_dict_like(to_replace):
         raise TypeError(
             "Expecting 'to_replace' to be a dict, got invalid type "
-            f"{type(to_replace).__name__!r}"
+            f"{type(to_replace).__name__!r}",
         )
 
     for left_right, value in to_replace.items():
         if not (is_list_like(left_right) and len(left_right) == 2):
             raise ValueError(
                 "The key of dict should be a range type contains scalar element, "
-                "the first element must be greater than the second one"
+                "the first element must be greater than the second one",
             )
 
         s = between_replace(s, *left_right, value, inclusive=inclusive)

--- a/dtoolkit/accessor/series/values_to_dict.py
+++ b/dtoolkit/accessor/series/values_to_dict.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from dtoolkit.accessor.register import register_series_method  # noqa: F401
+from dtoolkit.accessor.register import register_series_method
 
 
 @register_series_method


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

An accessor is used to replace values in ``[left, right]`` with ``value``.
But actually `replace` can do this feature via `range` too.

```python
>>> s = pd.Series(range(10))
>>> s.replace({range(3): 'a', range(2, 5): 'b'})
0    a
1    a
2    b
3    b
4    b
5    5
6    6
7    7
8    8
9    9
dtype: object
```