### PR TITLE
CI: don't lint versioneer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ ci:
     for more information, see https://pre-commit.ci
   autoupdate_commit_msg: "BOT: pre-commit hooks autoupdate"
 
+exclude: "(versioneer.py|dtoolkit/_version.py)"
+
 repos:
   # import
   - repo: https://github.com/MarcoGorelli/absolufy-imports


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #658, https://github.com/Zeroto521/my-data-toolkit/pull/658/commits
- [x] whatsnew entry

![image](https://user-images.githubusercontent.com/25895405/185327544-7b95c83c-2013-462d-83a0-080675478433.png)

Do not lint versioneer codes.
Do 'lint' should be done at upstream.