### PR TITLE
DOC: Reforce pydata-sphinx-theme to v0.9.0

### DIFF
--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   # doc dependencies
   - sphinx
-  - pydata-sphinx-theme
+  - pydata-sphinx-theme=0.9.0
   - myst-parser
   - numpydoc
   - ipython


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes https://readthedocs.org/projects/my-data-toolkit/builds/17953942/, https://readthedocs.org/projects/my-data-toolkit/builds/17922092/
- [x] whatsnew entry

Latestly pydata-sphinx-theme released 0.10.x version.
This version seems having conflicts with sphinx.

<details>

<summary>`html build` log</summary>

```python
Running Sphinx v5.1.1
Matplotlib is building the font cache; this may take a moment.
making output directory... done
myst v0.18.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=['colon_fence'], disable_syntax=[], all_links_external=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, highlight_code_blocks=True, number_code_blocks=[], title_to_header=False, heading_anchors=None, heading_slug_func=None, footnote_transition=True, words_per_minute=200, sub_delimiters=('{', '}'), linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area')
[autosummary] generating autosummary for: changelog.md, guide.rst, guide/automl.md, guide/build_transformer.ipynb, guide/geographic_buffer.md, guide/installation.md, guide/tips_about_accessor.ipynb, guide/tips_about_getattr.ipynb, guide/transformer_description.md, guide/transformer_quickstart.ipynb, guide/workflow.md, index.rst, reference.rst, reference/accessor.rst, reference/geoaccessor.rst, reference/pipeline.rst, reference/transformer.rst, reference/utility.rst
[autosummary] generating autosummary for: /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.boolean.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.cols.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.decompose.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.drop_inf.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.drop_or_not.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.dropna_index.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.expand.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.fillna_regression.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.filter_in.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.accessor.dataframe.groupby_index.rst, ..., /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.RavelTF.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.ReplaceTF.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.Transformer.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.methodtf_factory.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.util._decorator.deprecated_alias.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.util._decorator.deprecated_kwargs.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.util._decorator.warning.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.util._exception.find_stack_level.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.util.parallelize.rst
WARNING: [autosummary] failed to import dtoolkit.pipeline.FeatureUnion.steps.
Possible hints:
* ImportError: 
* ModuleNotFoundError: No module named 'dtoolkit.pipeline.FeatureUnion'; 'dtoolkit.pipeline' is not a package
* AttributeError: type object 'FeatureUnion' has no attribute 'steps'
WARNING: [autosummary] failed to import dtoolkit.pipeline.Pipeline.steps.
Possible hints:
* AttributeError: type object 'Pipeline' has no attribute 'steps'
* ModuleNotFoundError: No module named 'dtoolkit.pipeline.Pipeline'; 'dtoolkit.pipeline' is not a package
* ImportError: 
WARNING: [autosummary] failed to import dtoolkit.transformer.DataFrameTF.transform_method.
Possible hints:
* ModuleNotFoundError: No module named 'dtoolkit.transformer.DataFrameTF'
* AttributeError: type object 'DataFrameTF' has no attribute 'transform_method'
* ImportError: 
WARNING: [autosummary] failed to import dtoolkit.transformer.NumpyTF.transform_method.
Possible hints:
* AttributeError: type object 'NumpyTF' has no attribute 'transform_method'
* ImportError: 
* ModuleNotFoundError: No module named 'dtoolkit.transformer.NumpyTF'
[autosummary] generating autosummary for: /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.fit.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.fit_transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.get_feature_names.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.get_feature_names_out.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.get_params.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.inverse_transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.n_features_in_.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.set_params.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.Pipeline.classes_.rst, ..., /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.ReplaceTF.update_invargs.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.fit.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.fit_transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.inverse_transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.inverse_transform_method.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.transform_method.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.update_invargs.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.Transformer.fit_transform.rst, /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.Transformer.inverse_transform.rst
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://pandas.pydata.org/pandas-docs/stable/objects.inv...
loading intersphinx inventory from https://numpy.org/doc/stable/objects.inv...
loading intersphinx inventory from https://scikit-learn.org/stable/objects.inv...
loading intersphinx inventory from https://geopandas.org/en/stable/objects.inv...
loading intersphinx inventory from https://shapely.readthedocs.io/en/stable/objects.inv...
loading intersphinx inventory from https://pyproj4.github.io/pyproj/stable/objects.inv...
loading intersphinx inventory from https://pygeos.readthedocs.io/en/stable/objects.inv...
loading intersphinx inventory from https://joblib.readthedocs.io/en/latest/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 18 source files that are out of date
updating environment: [new config] 254 added, 0 changed, 0 removed
reading sources... [  0%] changelog
reading sources... [  0%] guide
reading sources... [  1%] guide/automl
reading sources... [  1%] guide/build_transformer
reading sources... [  1%] guide/geographic_buffer
reading sources... [  2%] guide/installation
reading sources... [  2%] guide/tips_about_accessor
reading sources... [  3%] guide/tips_about_getattr
reading sources... [  3%] guide/transformer_description
reading sources... [  3%] guide/transformer_quickstart
reading sources... [  4%] guide/workflow
reading sources... [  4%] index
reading sources... [  5%] reference
reading sources... [  5%] reference/accessor
reading sources... [  5%] reference/api/dtoolkit.accessor.dataframe.boolean
reading sources... [  6%] reference/api/dtoolkit.accessor.dataframe.cols
reading sources... [  6%] reference/api/dtoolkit.accessor.dataframe.decompose
reading sources... [  7%] reference/api/dtoolkit.accessor.dataframe.drop_inf
reading sources... [  7%] reference/api/dtoolkit.accessor.dataframe.drop_or_not
reading sources... [  7%] reference/api/dtoolkit.accessor.dataframe.dropna_index
reading sources... [  8%] reference/api/dtoolkit.accessor.dataframe.expand
reading sources... [  8%] reference/api/dtoolkit.accessor.dataframe.fillna_regression
reading sources... [  9%] reference/api/dtoolkit.accessor.dataframe.filter_in
reading sources... [  9%] reference/api/dtoolkit.accessor.dataframe.groupby_index
reading sources... [  9%] reference/api/dtoolkit.accessor.dataframe.repeat
reading sources... [ 10%] reference/api/dtoolkit.accessor.dataframe.set_unique_index
reading sources... [ 10%] reference/api/dtoolkit.accessor.dataframe.to_series
reading sources... [ 11%] reference/api/dtoolkit.accessor.dataframe.top_n
reading sources... [ 11%] reference/api/dtoolkit.accessor.dataframe.values_to_dict
reading sources... [ 11%] reference/api/dtoolkit.accessor.index.to_set
reading sources... [ 12%] reference/api/dtoolkit.accessor.register_dataframe_method
reading sources... [ 12%] reference/api/dtoolkit.accessor.register_index_method
reading sources... [ 12%] reference/api/dtoolkit.accessor.register_method_factory
reading sources... [ 13%] reference/api/dtoolkit.accessor.register_series_method
reading sources... [ 13%] reference/api/dtoolkit.accessor.series.bin
reading sources... [ 14%] reference/api/dtoolkit.accessor.series.cols
reading sources... [ 14%] reference/api/dtoolkit.accessor.series.drop_inf
reading sources... [ 14%] reference/api/dtoolkit.accessor.series.dropna_index
reading sources... [ 15%] reference/api/dtoolkit.accessor.series.error_report
reading sources... [ 15%] reference/api/dtoolkit.accessor.series.eval
reading sources... [ 16%] reference/api/dtoolkit.accessor.series.expand
reading sources... [ 16%] reference/api/dtoolkit.accessor.series.filter_in
reading sources... [ 16%] reference/api/dtoolkit.accessor.series.getattr
reading sources... [ 17%] reference/api/dtoolkit.accessor.series.groupby_index
reading sources... [ 17%] reference/api/dtoolkit.accessor.series.jenks_bin
reading sources... [ 18%] reference/api/dtoolkit.accessor.series.jenks_breaks
reading sources... [ 18%] reference/api/dtoolkit.accessor.series.len
reading sources... [ 18%] reference/api/dtoolkit.accessor.series.query
reading sources... [ 19%] reference/api/dtoolkit.accessor.series.set_unique_index
reading sources... [ 19%] reference/api/dtoolkit.accessor.series.swap_index_values
reading sources... [ 20%] reference/api/dtoolkit.accessor.series.to_set
reading sources... [ 20%] reference/api/dtoolkit.accessor.series.top_n
reading sources... [ 20%] reference/api/dtoolkit.accessor.series.values_to_dict
reading sources... [ 21%] reference/api/dtoolkit.geoaccessor.dataframe.from_wkb
reading sources... [ 21%] reference/api/dtoolkit.geoaccessor.dataframe.from_wkt
reading sources... [ 22%] reference/api/dtoolkit.geoaccessor.dataframe.from_xy
reading sources... [ 22%] reference/api/dtoolkit.geoaccessor.dataframe.geocode
reading sources... [ 22%] reference/api/dtoolkit.geoaccessor.dataframe.to_geoframe
reading sources... [ 23%] reference/api/dtoolkit.geoaccessor.geodataframe.count_coordinates
reading sources... [ 23%] reference/api/dtoolkit.geoaccessor.geodataframe.drop_duplicates_geometry
reading sources... [ 24%] reference/api/dtoolkit.geoaccessor.geodataframe.drop_geometry
reading sources... [ 24%] reference/api/dtoolkit.geoaccessor.geodataframe.duplicated_geometry
reading sources... [ 24%] reference/api/dtoolkit.geoaccessor.geodataframe.duplicated_geometry_groups
reading sources... [ 25%] reference/api/dtoolkit.geoaccessor.geodataframe.geoarea
reading sources... [ 25%] reference/api/dtoolkit.geoaccessor.geodataframe.geobuffer
reading sources... [ 25%] reference/api/dtoolkit.geoaccessor.geodataframe.get_coordinates
reading sources... [ 26%] reference/api/dtoolkit.geoaccessor.geodataframe.has_hole
reading sources... [ 26%] reference/api/dtoolkit.geoaccessor.geodataframe.hole_counts
reading sources... [ 27%] reference/api/dtoolkit.geoaccessor.geodataframe.reverse_geocode
reading sources... [ 27%] reference/api/dtoolkit.geoaccessor.geodataframe.toposimplify
reading sources... [ 27%] reference/api/dtoolkit.geoaccessor.geoseries.count_coordinates
reading sources... [ 28%] reference/api/dtoolkit.geoaccessor.geoseries.drop_duplicates_geometry
reading sources... [ 28%] reference/api/dtoolkit.geoaccessor.geoseries.duplicated_geometry
reading sources... [ 29%] reference/api/dtoolkit.geoaccessor.geoseries.duplicated_geometry_groups
reading sources... [ 29%] reference/api/dtoolkit.geoaccessor.geoseries.geoarea
reading sources... [ 29%] reference/api/dtoolkit.geoaccessor.geoseries.geobuffer
reading sources... [ 30%] reference/api/dtoolkit.geoaccessor.geoseries.get_coordinates
reading sources... [ 30%] reference/api/dtoolkit.geoaccessor.geoseries.has_hole
reading sources... [ 31%] reference/api/dtoolkit.geoaccessor.geoseries.hole_counts
reading sources... [ 31%] reference/api/dtoolkit.geoaccessor.geoseries.reverse_geocode
reading sources... [ 31%] reference/api/dtoolkit.geoaccessor.geoseries.toposimplify
reading sources... [ 32%] reference/api/dtoolkit.geoaccessor.register_geodataframe_accessor
reading sources... [ 32%] reference/api/dtoolkit.geoaccessor.register_geodataframe_method
reading sources... [ 33%] reference/api/dtoolkit.geoaccessor.register_geoseries_accessor
reading sources... [ 33%] reference/api/dtoolkit.geoaccessor.register_geoseries_method
reading sources... [ 33%] reference/api/dtoolkit.geoaccessor.series.from_wkb
reading sources... [ 34%] reference/api/dtoolkit.geoaccessor.series.from_wkt
reading sources... [ 34%] reference/api/dtoolkit.geoaccessor.series.geocode
reading sources... [ 35%] reference/api/dtoolkit.geoaccessor.series.to_geoframe
reading sources... [ 35%] reference/api/dtoolkit.geoaccessor.series.to_geoseries
reading sources... [ 35%] reference/api/dtoolkit.pipeline.FeatureUnion
reading sources... [ 36%] reference/api/dtoolkit.pipeline.FeatureUnion.fit
reading sources... [ 36%] reference/api/dtoolkit.pipeline.FeatureUnion.fit_transform
reading sources... [ 37%] reference/api/dtoolkit.pipeline.FeatureUnion.get_feature_names
reading sources... [ 37%] reference/api/dtoolkit.pipeline.FeatureUnion.get_feature_names_out
reading sources... [ 37%] reference/api/dtoolkit.pipeline.FeatureUnion.get_params
reading sources... [ 38%] reference/api/dtoolkit.pipeline.FeatureUnion.inverse_transform
reading sources... [ 38%] reference/api/dtoolkit.pipeline.FeatureUnion.n_features_in_
reading sources... [ 38%] reference/api/dtoolkit.pipeline.FeatureUnion.set_params
reading sources... [ 39%] reference/api/dtoolkit.pipeline.FeatureUnion.transform
reading sources... [ 39%] reference/api/dtoolkit.pipeline.Pipeline
reading sources... [ 40%] reference/api/dtoolkit.pipeline.Pipeline.classes_
reading sources... [ 40%] reference/api/dtoolkit.pipeline.Pipeline.decision_function
reading sources... [ 40%] reference/api/dtoolkit.pipeline.Pipeline.feature_names_in_
reading sources... [ 41%] reference/api/dtoolkit.pipeline.Pipeline.fit
reading sources... [ 41%] reference/api/dtoolkit.pipeline.Pipeline.fit_predict
reading sources... [ 42%] reference/api/dtoolkit.pipeline.Pipeline.fit_transform
reading sources... [ 42%] reference/api/dtoolkit.pipeline.Pipeline.get_feature_names_out
reading sources... [ 42%] reference/api/dtoolkit.pipeline.Pipeline.get_params
reading sources... [ 43%] reference/api/dtoolkit.pipeline.Pipeline.inverse_transform
reading sources... [ 43%] reference/api/dtoolkit.pipeline.Pipeline.n_features_in_
reading sources... [ 44%] reference/api/dtoolkit.pipeline.Pipeline.named_steps
reading sources... [ 44%] reference/api/dtoolkit.pipeline.Pipeline.predict
reading sources... [ 44%] reference/api/dtoolkit.pipeline.Pipeline.predict_log_proba
reading sources... [ 45%] reference/api/dtoolkit.pipeline.Pipeline.predict_proba
reading sources... [ 45%] reference/api/dtoolkit.pipeline.Pipeline.score
reading sources... [ 46%] reference/api/dtoolkit.pipeline.Pipeline.score_samples
reading sources... [ 46%] reference/api/dtoolkit.pipeline.Pipeline.set_params
reading sources... [ 46%] reference/api/dtoolkit.pipeline.Pipeline.transform
reading sources... [ 47%] reference/api/dtoolkit.pipeline.make_pipeline
reading sources... [ 47%] reference/api/dtoolkit.pipeline.make_union
reading sources... [ 48%] reference/api/dtoolkit.transformer.AppendTF
reading sources... [ 48%] reference/api/dtoolkit.transformer.AppendTF.fit
reading sources... [ 48%] reference/api/dtoolkit.transformer.AppendTF.fit_transform
reading sources... [ 49%] reference/api/dtoolkit.transformer.AppendTF.inverse_transform
reading sources... [ 49%] reference/api/dtoolkit.transformer.AppendTF.inverse_transform_method
reading sources... [ 50%] reference/api/dtoolkit.transformer.AppendTF.transform
reading sources... [ 50%] reference/api/dtoolkit.transformer.AppendTF.transform_method
reading sources... [ 50%] reference/api/dtoolkit.transformer.AppendTF.update_invargs
reading sources... [ 51%] reference/api/dtoolkit.transformer.AssignTF
reading sources... [ 51%] reference/api/dtoolkit.transformer.AssignTF.fit
reading sources... [ 51%] reference/api/dtoolkit.transformer.AssignTF.fit_transform
reading sources... [ 52%] reference/api/dtoolkit.transformer.AssignTF.inverse_transform
reading sources... [ 52%] reference/api/dtoolkit.transformer.AssignTF.inverse_transform_method
reading sources... [ 53%] reference/api/dtoolkit.transformer.AssignTF.transform
reading sources... [ 53%] reference/api/dtoolkit.transformer.AssignTF.transform_method
reading sources... [ 53%] reference/api/dtoolkit.transformer.AssignTF.update_invargs
reading sources... [ 54%] reference/api/dtoolkit.transformer.DataFrameTF
reading sources... [ 54%] reference/api/dtoolkit.transformer.DataFrameTF.fit
reading sources... [ 55%] reference/api/dtoolkit.transformer.DataFrameTF.fit_transform
reading sources... [ 55%] reference/api/dtoolkit.transformer.DataFrameTF.inverse_transform
reading sources... [ 55%] reference/api/dtoolkit.transformer.DataFrameTF.inverse_transform_method
reading sources... [ 56%] reference/api/dtoolkit.transformer.DataFrameTF.transform
reading sources... [ 56%] reference/api/dtoolkit.transformer.DataFrameTF.update_invargs
reading sources... [ 57%] reference/api/dtoolkit.transformer.DropTF
reading sources... [ 57%] reference/api/dtoolkit.transformer.DropTF.fit
reading sources... [ 57%] reference/api/dtoolkit.transformer.DropTF.fit_transform
reading sources... [ 58%] reference/api/dtoolkit.transformer.DropTF.inverse_transform
reading sources... [ 58%] reference/api/dtoolkit.transformer.DropTF.inverse_transform_method
reading sources... [ 59%] reference/api/dtoolkit.transformer.DropTF.transform
reading sources... [ 59%] reference/api/dtoolkit.transformer.DropTF.transform_method
reading sources... [ 59%] reference/api/dtoolkit.transformer.DropTF.update_invargs
reading sources... [ 60%] reference/api/dtoolkit.transformer.EvalTF
reading sources... [ 60%] reference/api/dtoolkit.transformer.EvalTF.fit
reading sources... [ 61%] reference/api/dtoolkit.transformer.EvalTF.fit_transform
reading sources... [ 61%] reference/api/dtoolkit.transformer.EvalTF.inverse_transform
reading sources... [ 61%] reference/api/dtoolkit.transformer.EvalTF.inverse_transform_method
reading sources... [ 62%] reference/api/dtoolkit.transformer.EvalTF.transform
reading sources... [ 62%] reference/api/dtoolkit.transformer.EvalTF.transform_method
reading sources... [ 62%] reference/api/dtoolkit.transformer.EvalTF.update_invargs
reading sources... [ 63%] reference/api/dtoolkit.transformer.FillnaTF
reading sources... [ 63%] reference/api/dtoolkit.transformer.FillnaTF.fit
reading sources... [ 64%] reference/api/dtoolkit.transformer.FillnaTF.fit_transform
reading sources... [ 64%] reference/api/dtoolkit.transformer.FillnaTF.inverse_transform
reading sources... [ 64%] reference/api/dtoolkit.transformer.FillnaTF.inverse_transform_method
reading sources... [ 65%] reference/api/dtoolkit.transformer.FillnaTF.transform
reading sources... [ 65%] reference/api/dtoolkit.transformer.FillnaTF.transform_method
reading sources... [ 66%] reference/api/dtoolkit.transformer.FillnaTF.update_invargs
reading sources... [ 66%] reference/api/dtoolkit.transformer.FilterInTF
reading sources... [ 66%] reference/api/dtoolkit.transformer.FilterInTF.fit
reading sources... [ 67%] reference/api/dtoolkit.transformer.FilterInTF.fit_transform
reading sources... [ 67%] reference/api/dtoolkit.transformer.FilterInTF.inverse_transform
reading sources... [ 68%] reference/api/dtoolkit.transformer.FilterInTF.inverse_transform_method
reading sources... [ 68%] reference/api/dtoolkit.transformer.FilterInTF.transform
reading sources... [ 68%] reference/api/dtoolkit.transformer.FilterInTF.transform_method
reading sources... [ 69%] reference/api/dtoolkit.transformer.FilterInTF.update_invargs
reading sources... [ 69%] reference/api/dtoolkit.transformer.GetTF
reading sources... [ 70%] reference/api/dtoolkit.transformer.GetTF.fit
reading sources... [ 70%] reference/api/dtoolkit.transformer.GetTF.fit_transform
reading sources... [ 70%] reference/api/dtoolkit.transformer.GetTF.inverse_transform
reading sources... [ 71%] reference/api/dtoolkit.transformer.GetTF.inverse_transform_method
reading sources... [ 71%] reference/api/dtoolkit.transformer.GetTF.transform
reading sources... [ 72%] reference/api/dtoolkit.transformer.GetTF.transform_method
reading sources... [ 72%] reference/api/dtoolkit.transformer.GetTF.update_invargs
reading sources... [ 72%] reference/api/dtoolkit.transformer.MethodTF
reading sources... [ 73%] reference/api/dtoolkit.transformer.MethodTF.fit
reading sources... [ 73%] reference/api/dtoolkit.transformer.MethodTF.fit_transform
reading sources... [ 74%] reference/api/dtoolkit.transformer.MethodTF.inverse_transform
reading sources... [ 74%] reference/api/dtoolkit.transformer.MethodTF.inverse_transform_method
reading sources... [ 74%] reference/api/dtoolkit.transformer.MethodTF.transform
reading sources... [ 75%] reference/api/dtoolkit.transformer.MethodTF.transform_method
reading sources... [ 75%] reference/api/dtoolkit.transformer.MethodTF.update_invargs
reading sources... [ 75%] reference/api/dtoolkit.transformer.NumpyTF
reading sources... [ 76%] reference/api/dtoolkit.transformer.NumpyTF.fit
reading sources... [ 76%] reference/api/dtoolkit.transformer.NumpyTF.fit_transform
reading sources... [ 77%] reference/api/dtoolkit.transformer.NumpyTF.inverse_transform
reading sources... [ 77%] reference/api/dtoolkit.transformer.NumpyTF.inverse_transform_method
reading sources... [ 77%] reference/api/dtoolkit.transformer.NumpyTF.transform
reading sources... [ 78%] reference/api/dtoolkit.transformer.NumpyTF.update_invargs
reading sources... [ 78%] reference/api/dtoolkit.transformer.OneHotEncoder
reading sources... [ 79%] reference/api/dtoolkit.transformer.OneHotEncoder.fit
reading sources... [ 79%] reference/api/dtoolkit.transformer.OneHotEncoder.fit_transform
reading sources... [ 79%] reference/api/dtoolkit.transformer.OneHotEncoder.get_feature_names
reading sources... [ 80%] reference/api/dtoolkit.transformer.OneHotEncoder.get_feature_names_out
reading sources... [ 80%] reference/api/dtoolkit.transformer.OneHotEncoder.get_params
reading sources... [ 81%] reference/api/dtoolkit.transformer.OneHotEncoder.infrequent_categories_
reading sources... [ 81%] reference/api/dtoolkit.transformer.OneHotEncoder.inverse_transform
reading sources... [ 81%] reference/api/dtoolkit.transformer.OneHotEncoder.set_params
reading sources... [ 82%] reference/api/dtoolkit.transformer.OneHotEncoder.transform
reading sources... [ 82%] reference/api/dtoolkit.transformer.QueryTF
reading sources... [ 83%] reference/api/dtoolkit.transformer.QueryTF.fit
reading sources... [ 83%] reference/api/dtoolkit.transformer.QueryTF.fit_transform
reading sources... [ 83%] reference/api/dtoolkit.transformer.QueryTF.inverse_transform
reading sources... [ 84%] reference/api/dtoolkit.transformer.QueryTF.inverse_transform_method
reading sources... [ 84%] reference/api/dtoolkit.transformer.QueryTF.transform
reading sources... [ 85%] reference/api/dtoolkit.transformer.QueryTF.transform_method
reading sources... [ 85%] reference/api/dtoolkit.transformer.QueryTF.update_invargs
reading sources... [ 85%] reference/api/dtoolkit.transformer.RavelTF
reading sources... [ 86%] reference/api/dtoolkit.transformer.RavelTF.fit
reading sources... [ 86%] reference/api/dtoolkit.transformer.RavelTF.fit_transform
reading sources... [ 87%] reference/api/dtoolkit.transformer.RavelTF.inverse_transform
reading sources... [ 87%] reference/api/dtoolkit.transformer.RavelTF.inverse_transform_method
reading sources... [ 87%] reference/api/dtoolkit.transformer.RavelTF.transform
reading sources... [ 88%] reference/api/dtoolkit.transformer.RavelTF.transform_method
reading sources... [ 88%] reference/api/dtoolkit.transformer.RavelTF.update_invargs
reading sources... [ 88%] reference/api/dtoolkit.transformer.ReplaceTF
reading sources... [ 89%] reference/api/dtoolkit.transformer.ReplaceTF.fit
reading sources... [ 89%] reference/api/dtoolkit.transformer.ReplaceTF.fit_transform
reading sources... [ 90%] reference/api/dtoolkit.transformer.ReplaceTF.inverse_transform
reading sources... [ 90%] reference/api/dtoolkit.transformer.ReplaceTF.inverse_transform_method
reading sources... [ 90%] reference/api/dtoolkit.transformer.ReplaceTF.transform
reading sources... [ 91%] reference/api/dtoolkit.transformer.ReplaceTF.transform_method
reading sources... [ 91%] reference/api/dtoolkit.transformer.ReplaceTF.update_invargs
reading sources... [ 92%] reference/api/dtoolkit.transformer.SelectDtypesTF
reading sources... [ 92%] reference/api/dtoolkit.transformer.SelectDtypesTF.fit
reading sources... [ 92%] reference/api/dtoolkit.transformer.SelectDtypesTF.fit_transform
reading sources... [ 93%] reference/api/dtoolkit.transformer.SelectDtypesTF.inverse_transform
reading sources... [ 93%] reference/api/dtoolkit.transformer.SelectDtypesTF.inverse_transform_method
reading sources... [ 94%] reference/api/dtoolkit.transformer.SelectDtypesTF.transform
reading sources... [ 94%] reference/api/dtoolkit.transformer.SelectDtypesTF.transform_method
reading sources... [ 94%] reference/api/dtoolkit.transformer.SelectDtypesTF.update_invargs
reading sources... [ 95%] reference/api/dtoolkit.transformer.Transformer
reading sources... [ 95%] reference/api/dtoolkit.transformer.Transformer.fit_transform
reading sources... [ 96%] reference/api/dtoolkit.transformer.Transformer.inverse_transform
reading sources... [ 96%] reference/api/dtoolkit.transformer.methodtf_factory
reading sources... [ 96%] reference/api/dtoolkit.util._decorator.deprecated_alias
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/numpydoc/docscrape.py:449: UserWarning: potentially wrong underline length... 
Parameters 
----------- in 
Used as a decorator when deprecating old function argument names, while keeping
backwards compatibility.... in the docstring of deprecated_alias in /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/util/_decorator/deprecated_alias.py.
  warn(msg)
reading sources... [ 97%] reference/api/dtoolkit.util._decorator.deprecated_kwargs
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/numpydoc/docscrape.py:449: UserWarning: potentially wrong underline length... 
Parameters 
----------- in 
Used as a decorator when deprecating function keyword argument names.
... in the docstring of deprecated_kwargs in /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/util/_decorator/deprecated_kwargs.py.
  warn(msg)
reading sources... [ 97%] reference/api/dtoolkit.util._decorator.warning
reading sources... [ 98%] reference/api/dtoolkit.util._exception.find_stack_level
reading sources... [ 98%] reference/api/dtoolkit.util.parallelize
reading sources... [ 98%] reference/geoaccessor
reading sources... [ 99%] reference/pipeline
reading sources... [ 99%] reference/transformer
reading sources... [100%] reference/utility
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/numpydoc/docscrape.py:449: UserWarning: potentially wrong underline length... 
Parameters 
----------- in 
Used as a decorator when deprecating old function argument names, while keeping
backwards compatibility.... in the docstring of deprecated_alias in /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/util/_decorator/deprecated_alias.py.
  warn(msg)
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/numpydoc/docscrape.py:449: UserWarning: potentially wrong underline length... 
Parameters 
----------- in 
Used as a decorator when deprecating function keyword argument names.
... in the docstring of deprecated_kwargs in /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/util/_decorator/deprecated_kwargs.py.
  warn(msg)

/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/accessor/dataframe/expand.py:docstring of dtoolkit.accessor.dataframe.expand.expand:: WARNING: image file not readable: ../../_static/expand-vs-explode.svg
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/accessor/series/expand.py:docstring of dtoolkit.accessor.series.expand.expand:: WARNING: image file not readable: ../../_static/expand-vs-explode.svg
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geodataframe/geobuffer.py:docstring of dtoolkit.geoaccessor.geodataframe.geobuffer.geobuffer:25: WARNING: Bullet list ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geodataframe/geobuffer.py:docstring of dtoolkit.geoaccessor.geodataframe.geobuffer.geobuffer:26: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geodataframe/geobuffer.py:docstring of dtoolkit.geoaccessor.geodataframe.geobuffer.geobuffer:27: WARNING: Bullet list ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geodataframe/toposimplify.py:docstring of dtoolkit.geoaccessor.geodataframe.toposimplify.toposimplify:: WARNING: image file not readable: ../../_static/simplify-vs-toposimplify.png
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geoseries/geobuffer.py:docstring of dtoolkit.geoaccessor.geoseries.geobuffer.geobuffer:25: WARNING: Bullet list ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geoseries/geobuffer.py:docstring of dtoolkit.geoaccessor.geoseries.geobuffer.geobuffer:26: WARNING: Block quote ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geoseries/geobuffer.py:docstring of dtoolkit.geoaccessor.geoseries.geobuffer.geobuffer:27: WARNING: Bullet list ends without a blank line; unexpected unindent.
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/dtoolkit/geoaccessor/geoseries/toposimplify.py:docstring of dtoolkit.geoaccessor.geoseries.toposimplify.toposimplify:: WARNING: image file not readable: ../../_static/simplify-vs-toposimplify.png
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.FeatureUnion.n_features_in_.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.Pipeline.classes_.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.Pipeline.feature_names_in_.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.Pipeline.n_features_in_.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.pipeline.Pipeline.named_steps.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.AppendTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.AssignTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.DataFrameTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.DropTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.EvalTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.FillnaTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.FilterInTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.GetTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.MethodTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.MethodTF.transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.NumpyTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.OneHotEncoder.infrequent_categories_.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.QueryTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.RavelTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.ReplaceTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/checkouts/latest/doc/source/reference/api/dtoolkit.transformer.SelectDtypesTF.inverse_transform_method.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [  0%] changelog

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1095, in handle_page
    output = self.templates.render(templatename, ctx)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/readthedocs_ext/readthedocs.py", line 185, in rtd_render
    content = old_render(template, render_context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/jinja2glue.py", line 189, in render
    return self.environment.get_template(template).render(context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/jinja2/environment.py", line 1291, in render
    self.environment.handle_exception()
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/themes/basic/page.html", line 10, in top-level template code
    {%- extends "layout.html" %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html", line 25, in top-level template code
    {% set remove_sidebar_secondary = (meta is defined and meta is not none
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/themes/basic/../basic/layout.html", line 170, in top-level template code
    {%- block content %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html", line 75, in block 'content'
    {% block docs_navbar %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html", line 77, in block 'docs_navbar'
    {%- include "sections/header.html" %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html", line 16, in top-level template code
    {% include navbar_item %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html", line 6, in top-level template code
    {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown) }}
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/jinja2/sandbox.py", line 393, in call
    return __context.call(__obj, *args, **kwargs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/__init__.py", line 250, in generate_header_nav_html
    title = app.env.titles[page].astext()
KeyError: 'self'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/cmd/build.py", line 277, in build_main
    app.build(args.force_all, filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/application.py", line 349, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 301, in build_update
    self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 367, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 559, in write
    self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 569, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 671, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/my-data-toolkit/conda/latest/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1102, in handle_page
    raise ThemeError(__("An error happened in rendering the page %s.\nReason: %r") %
sphinx.errors.ThemeError: An error happened in rendering the page changelog.
Reason: KeyError('self')

Theme error:
An error happened in rendering the page changelog.
Reason: KeyError('self')
```


</details>