### PR TITLE
BLD: pygeos isn't an optional dependency anymore

### DIFF
--- a/ci/env/310-minimal.yaml
+++ b/ci/env/310-minimal.yaml
@@ -8,7 +8,7 @@ dependencies:
   # optional
   - scikit-learn=1.1
   - geopandas=0.10.0
-  - pygeos=0.11.1
+  - pygeos
   - geopy
   - topojson
   # testing

--- a/ci/env/38-minimal.yaml
+++ b/ci/env/38-minimal.yaml
@@ -8,7 +8,7 @@ dependencies:
   # optional
   - scikit-learn=1.1
   - geopandas=0.10.0
-  - pygeos=0.8
+  - pygeos
   - geopy
   - topojson
   # testing

--- a/ci/env/39-minimal.yaml
+++ b/ci/env/39-minimal.yaml
@@ -8,7 +8,7 @@ dependencies:
   # optional
   - scikit-learn=1.1
   - geopandas=0.10.0
-  - pygeos=0.8
+  - pygeos
   - geopy
   - topojson
   # testing

--- a/ci/env/dev.yaml
+++ b/ci/env/dev.yaml
@@ -17,6 +17,7 @@ dependencies:
   - fiona
   - pyproj
   - shapely
+  - pygeos
   - geopy
   - topojson
   # testing
@@ -32,4 +33,3 @@ dependencies:
     # optional
     - git+https://github.com/scikit-learn/scikit-learn
     - git+https://github.com/geopandas/geopandas
-    - git+https://github.com/pygeos/pygeos

--- a/doc/source/guide/installation.md
+++ b/doc/source/guide/installation.md
@@ -18,7 +18,6 @@ Optional Dependencies:
 - {mod}`dtoolkit.geoaccessor` requires dependencies
 
   - GeoPandas (>= 0.10.0)
-  - PyGEOS (>= 0.11.1)
 
 ### Different Python Version Minimal Dependencies
 
@@ -58,7 +57,7 @@ conda create -n dtoolkit_env
 conda activate dtoolkit_env
 conda config --env --add channels conda-forge
 conda config --env --set channel_priority strict
-conda install python=3 pandas scikit-learn geopandas pygeos
+conda install python=3 pandas scikit-learn geopandas
 pip install my-data-toolkit
 ```
 

--- a/dtoolkit/geoaccessor/geodataframe/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geodataframe/count_coordinates.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 import geopandas as gpd
 import pandas as pd
 from pandas.util._decorators import doc
@@ -9,29 +7,6 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 
 @register_geodataframe_method
-@doc(
-    s_count_coordinates,
-    klass=":class:`~geopandas.GeoDataFrame`",
-    examples=dedent(
-        """
-    Examples
-    --------
-    >>> import dtoolkit.geoaccessor
-    >>> import geopandas as gpd
-    >>> d = gpd.GeoSeries.from_wkt(["POINT (0 0)", "LINESTRING (2 2, 4 4)", None])
-    >>> d = d.to_frame("geometry")
-    >>> d
-                                            geometry
-    0                        POINT (0.00000 0.00000)
-    1  LINESTRING (2.00000 2.00000, 4.00000 4.00000)
-    2                                           None
-    >>> d.count_coordinates()
-    0    1
-    1    2
-    2    0
-    Name: geometry, dtype: int64
-    """,
-    ),
-)
+@doc(s_count_coordinates, klass=":class:`~geopandas.GeoDataFrame`")
 def count_coordinates(df: gpd.GeoDataFrame, /) -> pd.Series:
     return s_count_coordinates(df.geometry)

--- a/dtoolkit/geoaccessor/geodataframe/get_coordinates.py
+++ b/dtoolkit/geoaccessor/geodataframe/get_coordinates.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 import geopandas as gpd
 import pandas as pd
 from pandas.util._decorators import doc
@@ -9,29 +7,6 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 
 @register_geodataframe_method
-@doc(
-    s_get_coordinates,
-    klass=":class:`~geopandas.GeoDataFrame`",
-    examples=dedent(
-        """
-    Examples
-    --------
-    >>> import dtoolkit.geoaccessor
-    >>> import geopandas as gpd
-    >>> d = gpd.GeoSeries.from_wkt(["POINT (0 0)", "LINESTRING (2 2, 4 4)", None])
-    >>> d = d.to_frame("geometry")
-    >>> d
-                                            geometry
-    0                        POINT (0.00000 0.00000)
-    1  LINESTRING (2.00000 2.00000, 4.00000 4.00000)
-    2                                           None
-    >>> d.get_coordinates()
-    0                [[0.0, 0.0]]
-    1    [[2.0, 2.0], [4.0, 4.0]]
-    2                          []
-    Name: geometry, dtype: object
-    """,
-    ),
-)
+@doc(s_get_coordinates, klass=":class:`~geopandas.GeoDataFrame`")
 def get_coordinates(df: gpd.GeoDataFrame, /, **kwargs) -> pd.Series:
     return s_get_coordinates(df.geometry, **kwargs)

--- a/dtoolkit/geoaccessor/geoseries/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/count_coordinates.py
@@ -37,7 +37,7 @@ def count_coordinates(s: gpd.GeoSeries, /) -> pd.Series:
     --------
     >>> import dtoolkit.geoaccessor
     >>> import geopandas as gpd
-    >>> dF = gpd.GeoSeries.from_wkt(
+    >>> df = gpd.GeoSeries.from_wkt(
     ...     [
     ...         "POINT (0 0)",
     ...         "LINESTRING (2 2, 4 4)",

--- a/dtoolkit/geoaccessor/geoseries/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/count_coordinates.py
@@ -1,6 +1,3 @@
-from functools import partial
-from textwrap import dedent
-
 import geopandas as gpd
 import pandas as pd
 from pandas.util._decorators import doc
@@ -9,28 +6,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-@doc(
-    klass=":class:`~geopandas.GeoSeries`",
-    examples=dedent(
-        """
-    Examples
-    --------
-    >>> import dtoolkit.geoaccessor
-    >>> import geopandas as gpd
-    >>> s = gpd.GeoSeries.from_wkt(["POINT (0 0)", "LINESTRING (2 2, 4 4)", None])
-    >>> s
-    0                          POINT (0.00000 0.00000)
-    1    LINESTRING (2.00000 2.00000, 4.00000 4.00000)
-    2                                             None
-    dtype: geometry
-    >>> s.count_coordinates()
-    0    1
-    1    2
-    2    0
-    dtype: int64
-    """,
-    ),
-)
+@doc(klass=":class:`~geopandas.GeoSeries`")
 def count_coordinates(s: gpd.GeoSeries, /) -> pd.Series:
     """
     Counts the number of coordinate pairs in each geometry of {klass}.
@@ -56,7 +32,28 @@ def count_coordinates(s: gpd.GeoSeries, /) -> pd.Series:
 
     pygeos.coordinates.count_coordinates
         The core algorithm of this accessor.
-    {examples}
+
+    Examples
+    --------
+    >>> import dtoolkit.geoaccessor
+    >>> import geopandas as gpd
+    >>> dF = gpd.GeoSeries.from_wkt(
+    ...     [
+    ...         "POINT (0 0)",
+    ...         "LINESTRING (2 2, 4 4)",
+    ...         None,
+    ...     ],
+    ... ).to_frame("geometry")
+    >>> df
+                                            geometry
+    0                        POINT (0.00000 0.00000)
+    1  LINESTRING (2.00000 2.00000, 4.00000 4.00000)
+    2                                           None
+    >>> df.count_coordinates()
+    0    1
+    1    2
+    2    0
+    Name: geometry, dtype: int64
     """
     from pygeos import count_coordinates, from_shapely
 

--- a/dtoolkit/geoaccessor/geoseries/count_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/count_coordinates.py
@@ -1,8 +1,8 @@
+from functools import partial
 from textwrap import dedent
 
 import geopandas as gpd
 import pandas as pd
-import pygeos
 from pandas.util._decorators import doc
 
 from dtoolkit.geoaccessor.register import register_geoseries_method
@@ -41,6 +41,11 @@ def count_coordinates(s: gpd.GeoSeries, /) -> pd.Series:
     -------
     Series
 
+    Raises
+    ------
+    ModuleNotFoundError
+        If don't have module named 'pygeos'.
+
     See Also
     --------
     dtoolkit.geoaccessor.geoseries.count_coordinates
@@ -53,9 +58,6 @@ def count_coordinates(s: gpd.GeoSeries, /) -> pd.Series:
         The core algorithm of this accessor.
     {examples}
     """
+    from pygeos import count_coordinates, from_shapely
 
-    return s.apply(
-        lambda x: pygeos.count_coordinates(
-            pygeos.from_shapely(x),
-        ),
-    )
+    return s.apply(lambda x: count_coordinates(from_shapely(x)))

--- a/dtoolkit/geoaccessor/geoseries/get_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/get_coordinates.py
@@ -2,7 +2,6 @@ from textwrap import dedent
 
 import geopandas as gpd
 import pandas as pd
-import pygeos
 from pandas.util._decorators import doc
 
 from dtoolkit.geoaccessor.register import register_geoseries_method
@@ -47,6 +46,11 @@ def get_coordinates(s: gpd.GeoSeries, /, **kwargs) -> pd.Series:
     -------
     Series
 
+    Raises
+    ------
+    ModuleNotFoundError
+        If don't have module named 'pygeos'.
+
     See Also
     --------
     dtoolkit.geoaccessor.geoseries.get_coordinates
@@ -59,7 +63,6 @@ def get_coordinates(s: gpd.GeoSeries, /, **kwargs) -> pd.Series:
         The core algorithm of this accessor.
     {examples}
     """
+    from pygeos import from_shapely, get_coordinates
 
-    return s.apply(
-        lambda x: pygeos.get_coordinates(pygeos.from_shapely(x), **kwargs),
-    )
+    return s.apply(lambda x: get_coordinates(from_shapely(x), **kwargs))

--- a/dtoolkit/geoaccessor/geoseries/get_coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/get_coordinates.py
@@ -1,5 +1,3 @@
-from textwrap import dedent
-
 import geopandas as gpd
 import pandas as pd
 from pandas.util._decorators import doc
@@ -8,28 +6,7 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-@doc(
-    klass=":class:`~geopandas.GeoSeries`",
-    examples=dedent(
-        """
-    Examples
-    --------
-    >>> import dtoolkit.geoaccessor
-    >>> import geopandas as gpd
-    >>> s = gpd.GeoSeries.from_wkt(["POINT (0 0)", "LINESTRING (2 2, 4 4)", None])
-    >>> s
-    0                          POINT (0.00000 0.00000)
-    1    LINESTRING (2.00000 2.00000, 4.00000 4.00000)
-    2                                             None
-    dtype: geometry
-    >>> s.get_coordinates()
-    0                [[0.0, 0.0]]
-    1    [[2.0, 2.0], [4.0, 4.0]]
-    2                          []
-    dtype: object
-    """,
-    ),
-)
+@doc(klass=":class:`~geopandas.GeoSeries`")
 def get_coordinates(s: gpd.GeoSeries, /, **kwargs) -> pd.Series:
     """
     Gets coordinates from each geometry of {klass}.
@@ -61,7 +38,28 @@ def get_coordinates(s: gpd.GeoSeries, /, **kwargs) -> pd.Series:
 
     pygeos.coordinates.get_coordinates
         The core algorithm of this accessor.
-    {examples}
+
+    Examples
+    --------
+    >>> import dtoolkit.geoaccessor
+    >>> import geopandas as gpd
+    >>> df = gpd.GeoSeries.from_wkt(
+    ...     [
+    ...         "POINT (0 0)",
+    ...         "LINESTRING (2 2, 4 4)",
+    ...         None,
+    ...     ],
+    ... ).to_frame("geometry")
+    >>> df
+                                            geometry
+    0                        POINT (0.00000 0.00000)
+    1  LINESTRING (2.00000 2.00000, 4.00000 4.00000)
+    2                                           None
+    >>> df.get_coordinates()
+    0                [[0.0, 0.0]]
+    1    [[2.0, 2.0], [4.0, 4.0]]
+    2                          []
+    Name: geometry, dtype: object
     """
     from pygeos import from_shapely, get_coordinates
 

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -9,7 +9,7 @@ dependencies:
   # optional
   - scikit-learn >= 1.1
   - geopandas >= 0.10.0
-  - pygeos >= 0.11.1
+  - pygeos
   - geopy
   - jenkspy
   - topojson

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,7 +7,7 @@ dependencies:
   # optional
   - scikit-learn >= 1.1
   - geopandas >= 0.10.0
-  - pygeos >= 0.11.1
+  - pygeos
   - geopy
   - jenkspy
   - topojson

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,6 @@ python_requires = >=3.8
 opt =
     scikit-learn >= 1.1; python_version >= "3.8"
     geopandas >= 0.10.0; python_version >= "3.8"
-    pygeos >= 0.8; python_version <= "3.9"
-    pygeos >= 0.11.1; python_version >= "3.10"
 test =
     pytest
     pytest-xdist


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

While `import dtoolkit.geoaccessor` without pygeos, there wouldn't raise an error.