### PR TITLE
ENH: New geoaccessor for GeoSeries to return tuple of coordinates `(x, y)`

### DIFF
--- a/doc/source/reference/geoaccessor.rst
+++ b/doc/source/reference/geoaccessor.rst
@@ -23,6 +23,7 @@ GeoSeries Accessor
     hole_counts
     reverse_geocode
     toposimplify
+    xy
 
 
 GeoDataFrame Accessor

--- a/dtoolkit/geoaccessor/geoseries/__init__.py
+++ b/dtoolkit/geoaccessor/geoseries/__init__.py
@@ -23,3 +23,4 @@ from dtoolkit.geoaccessor.geoseries.has_hole import has_hole  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.hole_counts import hole_counts  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.reverse_geocode import reverse_geocode  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.toposimplify import toposimplify  # noqa: F401
+from dtoolkit.geoaccessor.geoseries.xy import xy  # noqa: F401

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -25,7 +25,7 @@ def xy(s: gpd.GeoSeries, /) -> pd.Series:
     >>> import geopandas as gpd
     >>> from shapely.geometry import Point
     >>> s = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
-    >>> s.xy
+    >>> s.xy()
     0    (1.0, 1.0)
     1    (2.0, 2.0)
     2    (3.0, 3.0)

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -1,7 +1,6 @@
 import geopandas as gpd
 import pandas as pd
 
-from dtoolkit.geoaccessor.geoseries.hole_counts import hole_counts
 from dtoolkit.geoaccessor.register import register_geoseries_method
 
 

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -1,0 +1,35 @@
+import geopandas as gpd
+import pandas as pd
+from dtoolkit.geoaccessor.geoseries.hole_counts import hole_counts
+from dtoolkit.geoaccessor.register import register_geoseries_method
+
+
+@register_geoseries_method
+def xy(s: gpd.GeoSeries, /) -> pd.Series:
+    """
+    Return the x and y location of Point geometries in a GeoSeries.
+
+    Returns
+    -------
+    Series
+        tuple of x and y coordinates.
+
+    See Also
+    --------
+    GeoSeries.x
+    GeoSeries.y
+
+    Examples
+    --------
+    >>> import dtoolkit.geoaccessor
+    >>> import geopandas as gpd
+    >>> from shapely.geometry import Point
+    >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+    >>> s.xy
+    0    (1.0, 1.0)
+    1    (2.0, 2.0)
+    2    (3.0, 3.0)
+    dtype: object
+    """
+
+    return pd.concat((s.x, s.y), axis=1).apply(tuple, axis=1)

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -24,7 +24,7 @@ def xy(s: gpd.GeoSeries, /) -> pd.Series:
     >>> import dtoolkit.geoaccessor
     >>> import geopandas as gpd
     >>> from shapely.geometry import Point
-    >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+    >>> s = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
     >>> s.xy
     0    (1.0, 1.0)
     1    (2.0, 2.0)

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import pandas as pd
+
 from dtoolkit.geoaccessor.geoseries.hole_counts import hole_counts
 from dtoolkit.geoaccessor.register import register_geoseries_method
 

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -25,6 +25,11 @@ def xy(s: gpd.GeoSeries, /) -> pd.Series:
     >>> import geopandas as gpd
     >>> from shapely.geometry import Point
     >>> s = gpd.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
+    >>> s
+    0    POINT (1.00000 1.00000)
+    1    POINT (2.00000 2.00000)
+    2    POINT (3.00000 3.00000)
+    dtype: geometry
     >>> s.xy()
     0    (1.0, 1.0)
     1    (2.0, 2.0)

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -16,8 +16,8 @@ def xy(s: gpd.GeoSeries, /) -> pd.Series:
 
     See Also
     --------
-    GeoSeries.x
-    GeoSeries.y
+    geopandas.GeoSeries.x
+    geopandas.GeoSeries.y
 
     Examples
     --------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

as title

```python
    >>> import dtoolkit.geoaccessor
    >>> import geopandas as gpd
    >>> from shapely.geometry import Point
    >>> s = geopandas.GeoSeries([Point(1, 1), Point(2, 2), Point(3, 3)])
    >>> s.xy
    0    (1.0, 1.0)
    1    (2.0, 2.0)
    2    (3.0, 3.0)
    dtype: object
```