### PR TITLE
BUG: Fix `decompose` can't collapse dict

### DIFF
--- a/dtoolkit/accessor/dataframe/decompose.py
+++ b/dtoolkit/accessor/dataframe/decompose.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from itertools import chain
 from typing import Hashable
 from typing import TYPE_CHECKING
 
@@ -9,6 +8,7 @@ import pandas as pd
 
 from dtoolkit.accessor.dataframe.drop_or_not import drop_or_not
 from dtoolkit.accessor.register import register_dataframe_method
+from dtoolkit.accessor.series.expand import collapse
 
 if TYPE_CHECKING:
     from sklearn.base import TransformerMixin
@@ -163,12 +163,12 @@ def decompose(
                 ],
             ),
             index=df.index,
-            columns=chain.from_iterable(columns.keys()),
+            columns=collapse(columns.keys()),
         ).combine_first(
             drop_or_not(
                 df,
                 drop=drop,
-                columns=chain.from_iterable(columns.values()),
+                columns=collapse(columns.values()),
             ),
         )
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #664
- [x] whatsnew entry

```python
>>> from itertools import chain
>>> chain.from_iterable({'many-string': 'new_column'})
['m', 'a', 'n', 'y', '-', 's', 't', 'r', 'i', 'n', 'g']  # expected `['many-string']`
```