### PR TITLE
ENH: New accessor for Series to convert datetime type

### DIFF
--- a/doc/source/reference/accessor.rst
+++ b/doc/source/reference/accessor.rst
@@ -34,6 +34,7 @@ Series Accessor
     query
     set_unique_index
     swap_index_values
+    to_datetime
     to_set
     top_n
     values_to_dict

--- a/dtoolkit/accessor/series/__init__.py
+++ b/dtoolkit/accessor/series/__init__.py
@@ -15,6 +15,7 @@ from dtoolkit.accessor.series.len import len  # noqa: F401
 from dtoolkit.accessor.series.query import query  # noqa: F401
 from dtoolkit.accessor.series.set_unique_index import set_unique_index  # noqa: F401
 from dtoolkit.accessor.series.swap_index_values import swap_index_values  # noqa: F401
+from dtoolkit.accessor.series.to_datetime import to_datetime  # noqa: F401
 from dtoolkit.accessor.series.to_set import to_set  # noqa: F401
 from dtoolkit.accessor.series.top_n import top_n  # noqa: F401
 from dtoolkit.accessor.series.values_to_dict import values_to_dict  # noqa: F401

--- a/dtoolkit/accessor/series/to_datetime.py
+++ b/dtoolkit/accessor/series/to_datetime.py
@@ -24,12 +24,13 @@ def to_datetime(s: pd.Series, /, **kwargs) -> pd.Series:
     See Also
     --------
     pandas.to_datetime
-        The function that this method wraps.
 
-    janitor.functions.to_datetime
-        DataFrame version of this function. See `Janitor's documentation`__ for details.
+    Notes
+    -----
+    ``DataFrame.to_datetime`` could use `janitor.functions.to_datetime`__.
 
-    __ https://pyjanitor-devs.github.io/pyjanitor/api/functions/#janitor.functions.to_datetime
+    __ https://pyjanitor-devs.github.io/pyjanitor/api/functions/\
+#janitor.functions.to_datetime
 
     Examples
     --------

--- a/dtoolkit/accessor/series/to_datetime.py
+++ b/dtoolkit/accessor/series/to_datetime.py
@@ -1,0 +1,47 @@
+import pandas as pd
+
+from dtoolkit.accessor.register import register_series_method
+
+
+@register_series_method
+def to_datetime(s: pd.Series, /, **kwargs) -> pd.Series:
+    """
+    Convert Series to datetime type.
+
+    A sugary syntax wraps::
+
+        pd.to_datetime(s, **kwargs)
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments to pass to :meth:`pandas.to_datetime`.
+
+    See Also
+    --------
+    pandas.to_datetime
+        The function that this method wraps.
+
+    janitor.functions.to_datetime
+        DataFrame version of this function. See `Janitor's documentation`__ for details.
+
+    __ https://pyjanitor-devs.github.io/pyjanitor/api/functions/#janitor.functions.to_datetime
+
+    Examples
+    --------
+    >>> import dtoolkit.accessor
+    >>> import pandas as pd
+    >>> s = pd.Series(['20200101', '20200202', '20200303'])
+    >>> s
+    0    20200101
+    1    20200202
+    2    20200303
+    dtype: object
+    >>> s.to_datetime(format='%Y%m%d')
+    0   2020-01-01
+    1   2020-02-02
+    2   2020-03-03
+    dtype: datetime64[ns]
+    """
+
+    return pd.to_datetime(s, **kwargs)

--- a/dtoolkit/accessor/series/to_datetime.py
+++ b/dtoolkit/accessor/series/to_datetime.py
@@ -17,6 +17,10 @@ def to_datetime(s: pd.Series, /, **kwargs) -> pd.Series:
     **kwargs
         Keyword arguments to pass to :meth:`pandas.to_datetime`.
 
+    Returns
+    -------
+    Series
+
     See Also
     --------
     pandas.to_datetime


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

```python
    >>> import dtoolkit.accessor
    >>> import pandas as pd
    >>> s = pd.Series(['20200101', '20200202', '20200303'])
    >>> s
    0    20200101
    1    20200202
    2    20200303
    dtype: object
    >>> s.to_datetime(format='%Y%m%d')
    0   2020-01-01
    1   2020-02-02
    2   2020-03-03
    dtype: datetime64[ns]
```