### PR TITLE
MAINT: Use `gpd.GeoSeries.from_xy` instead of `gpd.points_from_xy`

### DIFF
--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -28,7 +28,7 @@ def from_xy(
     Generate :obj:`~geopandas.GeoDataFrame` of :obj:`~shapely.geometry.Point`
     geometries from columns of :obj:`~pandas.DataFrame`.
 
-    A sugary syntax wraps :meth:`geopandas.points_from_xy`.
+    A sugary syntax wraps :meth:`geopandas.GeoSeries.from_xy`.
 
     Parameters
     ----------
@@ -55,7 +55,6 @@ def from_xy(
 
     See Also
     --------
-    geopandas.points_from_xy
     geopandas.GeoSeries.from_xy
     dtoolkit.geoaccessor.dataframe.from_wkt
 
@@ -93,7 +92,7 @@ def from_xy(
             drop=drop,
             columns=[x, y] if z is None else [x, y, z],
         ),
-        geometry=gpd.points_from_xy(
+        geometry=gpd.GeoSeries.from_xy(
             df[x],
             df[y],
             z=df[z] if z is not None else z,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

`from_xy` vs. `points_from_xy`

`from_xy`:
- returns `GeoSeries`
- requires minimal geopandas 0.10.0

`points_from_xy`
- returns `GeometryArray`
- requires minimal geopandas 0.6.0