### PR TITLE
REV: "DOC: Remove 'pygeos' from doc/environment.yaml"

### DIFF
--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -7,6 +7,7 @@ dependencies:
   - pandas
   - scikit-learn
   - geopandas
+  # TODO: delete pygeos after shapely 2.x released
   - pygeos
 
   # doc dependencies

--- a/doc/environment.yaml
+++ b/doc/environment.yaml
@@ -7,6 +7,7 @@ dependencies:
   - pandas
   - scikit-learn
   - geopandas
+  - pygeos
 
   # doc dependencies
   - sphinx


### PR DESCRIPTION
Reverts Zeroto521/my-data-toolkit#695

This caused the documentation [breakout](https://my-data-toolkit.readthedocs.io/en/v0.0.18/guide/tips_about_accessor.html).
![image](https://user-images.githubusercontent.com/25895405/195981676-5569355d-2dff-4be6-ab39-b46fbdcdd7fe.png)
