### PR TITLE
ENH: New accessor for Index `filter`

### DIFF
--- a/doc/source/reference/accessor/index.rst
+++ b/doc/source/reference/accessor/index.rst
@@ -10,3 +10,11 @@ Conversion
     :toctree: ../api/
 
     to_set
+
+
+Reindexing / selection / label manipulation
+-------------------------------------------
+.. autosummary::
+    :toctree: ../api/
+
+    filter

--- a/dtoolkit/accessor/index/__init__.py
+++ b/dtoolkit/accessor/index/__init__.py
@@ -1,1 +1,2 @@
+from dtoolkit.accessor.index.filter import filter  # noqa: F401
 from dtoolkit.accessor.index.to_set import to_set  # noqa: F401

--- a/dtoolkit/accessor/index/filter.py
+++ b/dtoolkit/accessor/index/filter.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pandas.core.common import count_not_none
 from pandas.core.dtypes.common import ensure_str
 
-from dtoolkit.accessor import register_index_method
+from dtoolkit.accessor.register import register_index_method
 
 
 @register_index_method

--- a/dtoolkit/accessor/index/filter.py
+++ b/dtoolkit/accessor/index/filter.py
@@ -48,7 +48,30 @@ def filter(
     -----
     The ``items``, ``like``, and ``regex`` parameters are enforced to be mutually
     exclusive.
+
+    Examples
+    --------
+    >>> import dtoolkit.accessor
+    >>> import pandas as pd
+    >>> index = pd.Index(['one', 'two', 'three'])
+    >>> index
+    Index(['one', 'two', 'three'], dtype='object')
+
+    Select by name.
+
+    >>> index.filter(items=['one', 'three'])
+    Index(['one', 'three'], dtype='object')
+
+    Select by regular expression.
+
+    >>> index.filter(regex='e$')
+    Index(['one', 'three'], dtype='object')
+
+    Doesn't select containing 't'.
+    >>> index.filter(like='t', complement=True)
+    Index(['one'], dtype='object')
     """
+
     if count_not_none(items, like, regex) > 1:
         raise TypeError(
             "Keyword arguments `items`, `like`, or `regex` are mutually exclusive.",

--- a/dtoolkit/accessor/index/filter.py
+++ b/dtoolkit/accessor/index/filter.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from re import compile
+
+import pandas as pd
+from pandas.core.common import count_not_none
+from pandas.core.dtypes.common import ensure_str
+
+from dtoolkit.accessor import register_index_method
+
+
+@register_index_method
+def filter(
+    index: pd.Index,
+    /,
+    items=None,
+    like: str | None = None,
+    regex: str | None = None,
+    complement: bool = False,
+) -> pd.Index:
+    if count_not_none(items, like, regex) > 1:
+        raise TypeError(
+            "Keyword arguments `items`, `like`, or `regex` are mutually exclusive.",
+        )
+
+    if items:
+        choice = lambda x: (x not in items) if complement else (x in items)
+        return index.reindex((i in index for i in items if choice(i)))[0]
+    elif like:
+        condition = index.map(lambda x: like in ensure_str(x))
+    elif regex:
+        searcher = compile(regex).search
+        condition = index.map(lambda x: searcher(ensure_str(x)) is not None)
+    else:
+        raise TypeError("Must pass either `items`, `like`, or `regex`.")
+
+    return index[~condition] if complement else index[condition]

--- a/dtoolkit/accessor/index/filter.py
+++ b/dtoolkit/accessor/index/filter.py
@@ -18,6 +18,37 @@ def filter(
     regex: str | None = None,
     complement: bool = False,
 ) -> pd.Index:
+    """
+    Subset the Index according to the specified labels.
+
+    Parameters
+    ----------
+    items : list-like
+        Keep labels from axis which are in items.
+
+    like : str
+        Keep labels from axis for which "like in label == True".
+
+    regex : str (regular expression)
+        Keep labels from axis for which re.search(regex, label) == True.
+
+    complement : bool, default False
+        If True, return the complement of the result.
+
+    Returns
+    -------
+    Index
+
+    See Also
+    --------
+    pandas.Series.filter
+    pandas.DataFrame.filter
+
+    Notes
+    -----
+    The ``items``, ``like``, and ``regex`` parameters are enforced to be mutually
+    exclusive.
+    """
     if count_not_none(items, like, regex) > 1:
         raise TypeError(
             "Keyword arguments `items`, `like`, or `regex` are mutually exclusive.",

--- a/dtoolkit/accessor/index/filter.py
+++ b/dtoolkit/accessor/index/filter.py
@@ -30,7 +30,7 @@ def filter(
         Keep labels from axis for which "like in label == True".
 
     regex : str (regular expression)
-        Keep labels from axis for which re.search(regex, label) == True.
+        Keep labels from axis for which ``re.search(regex, label) == True``.
 
     complement : bool, default False
         If True, return the complement of the result.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

```python
    >>> index = pd.Index(['one', 'two', 'three'])

    # Doesn't select containing 't'.

    >>> index.filter(like='t', complement=True)
    Index(['one'], dtype='object')
```