### PR TITLE
ENH: `GeoSeries.xy` support to return DataFrame

### DIFF
--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -54,6 +54,9 @@ def xy(
     1    POINT (0.00000 2.00000)
     2    POINT (0.00000 3.00000)
     dtype: geometry
+
+    Get the x and y coordinates of each point as a tuple.
+
     >>> s.xy()
     0    (0.0, 1.0)
     1    (0.0, 2.0)
@@ -67,6 +70,14 @@ def xy(
     1    (2.0, 0.0)
     2    (3.0, 0.0)
     dtype: object
+
+    Set ``frame=True`` to return a DataFrame with x and y columns.
+
+    >>> s.xy(frame=True)
+         x    y
+    0  0.0  1.0
+    1  0.0  2.0
+    2  0.0  3.0
     """
 
     coords = pd.concat((s.x.rename(x), s.y.rename(y)), axis=1)

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -1,3 +1,5 @@
+from typing import Hashable
+
 import geopandas as gpd
 import pandas as pd
 
@@ -5,7 +7,14 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-def xy(s: gpd.GeoSeries, /, reverse: bool = False) -> pd.Series:
+def xy(
+    s: gpd.GeoSeries,
+    /,
+    reverse: bool = False,
+    frame: bool = False,
+    x: Hashable = "x",
+    y: Hashable = "y",
+) -> pd.Series:
     """
     Return the x and y location of Point geometries in a GeoSeries.
 
@@ -14,10 +23,20 @@ def xy(s: gpd.GeoSeries, /, reverse: bool = False) -> pd.Series:
     reverse : bool, default False
         If True, return (y, x) instead.
 
+    frame : bool, default False
+        If True, return a DataFrame instead of a Series.
+
+    x : str, default 'x'
+        Name of the x column if frame=True.
+
+    y : str, default 'y'
+        Name of the y column if frame=True.
+
     Returns
     -------
-    Series
-        tuple of coordinate.
+    Series or DataFrame
+        If frame=False, a Series with tuple of coordinate. else, a DataFrame with
+        x and y two columns.
 
     See Also
     --------
@@ -50,5 +69,9 @@ def xy(s: gpd.GeoSeries, /, reverse: bool = False) -> pd.Series:
     dtype: object
     """
 
-    coordinates = (s.y, s.x) if reverse else (s.x, s.y)
-    return pd.concat(coordinates, axis=1).apply(tuple, axis=1)
+    coords = pd.concat((s.x.rename(x), s.y.rename(y)), axis=1)
+
+    if reverse:
+        coords = coords.iloc[:, ::-1]
+
+    return coords if frame else coords.apply(tuple, axis=1)

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -3,6 +3,7 @@ from typing import Hashable
 import geopandas as gpd
 import pandas as pd
 
+from dtoolkit._typing import SeriesOrFrame
 from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
@@ -14,7 +15,7 @@ def xy(
     frame: bool = False,
     x: Hashable = "x",
     y: Hashable = "y",
-) -> pd.Series:
+) -> SeriesOrFrame:
     """
     Return the x and y location of Point geometries in a GeoSeries.
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

```python
    >>> import dtoolkit.geoaccessor
    >>> import geopandas as gpd
    >>> from shapely.geometry import Point
    >>> s = gpd.GeoSeries([Point(0, 1), Point(0, 2), Point(0, 3)])
    >>> s.xy(frame=True)
         x    y
    0  0.0  1.0
    1  0.0  2.0
    2  0.0  3.0
```