### PR TITLE
MAINT: Use `.is_monotonic_increasing` replace `.is_monotonic`

### DIFF
--- a/dtoolkit/accessor/series/set_unique_index.py
+++ b/dtoolkit/accessor/series/set_unique_index.py
@@ -35,7 +35,7 @@ def set_unique_index(s: pd.Series, /, **kwargs) -> pd.Series:
 
     See Also
     --------
-    pandas.Index.is_monotonic
+    pandas.Index.is_monotonic_increasing
     pandas.{klass}.reset_index
     dtoolkit.accessor.series.set_unique_index
     dtoolkit.accessor.dataframe.set_unique_index
@@ -84,7 +84,7 @@ def set_unique_index(s: pd.Series, /, **kwargs) -> pd.Series:
         )
         return s.reset_index(**kwargs)
 
-    elif not s.index.is_monotonic:
+    elif not s.index.is_monotonic_increasing:
         return s.reset_index(**kwargs)
 
     return s


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

`.is_monotonic` is depracated.

```python
  /home/runner/work/my-data-toolkit/my-data-toolkit/dtoolkit/accessor/series/set_unique_index.py:87: FutureWarning: is_monotonic is deprecated and will be removed in a future version. Use is_monotonic_increasing instead.
    elif not s.index.is_monotonic:
```