### PR TITLE
CI: versioneer updating only works on main branch

### DIFF
--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -5,6 +5,7 @@ on:
   schedule:
     - cron: "0 0 * * 0"
   push:
+    branches: [main]
     paths:
       - setup.cfg
       - setup.py


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Any push to main branch and versioneer related files will trigger updating workflow