### PR TITLE
CI: Remove `set-output`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,17 +30,11 @@ jobs:
 
       - name: Get Source Tarball Name
         id: tar
-        run: |
-          export type=tar
-          export file=$(ls dist/ | grep ${type})
-          echo "::set-output name=file::${file}"
+        run: echo "{file}=$(ls dist/ | grep tar)" >> $GITHUB_OUTPUT
 
       - name: Get Binary Wheel Name
         id: whl
-        run: |
-          export type=whl
-          export file=$(ls dist/ | grep ${type})
-          echo "::set-output name=file::${file}"
+        run: echo "{file}=$(ls dist/ | grep whl)" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry
