### PR TITLE
MAINT: Compat sklearn 1.2

### DIFF
--- a/dtoolkit/transformer/sklearn/OneHotEncoder.py
+++ b/dtoolkit/transformer/sklearn/OneHotEncoder.py
@@ -130,7 +130,12 @@ class OneHotEncoder(SKOneHotEncoder):
 
         Xt = super().transform(X)
 
-        if self.sparse is False and isinstance(X, (pd.Series, pd.DataFrame)):
+        if (
+            SKLEARN_GE_12
+            and not self.sparse_output
+            or not SKLEARN_GE_12
+            and not self.sparse
+        ) and isinstance(X, (pd.Series, pd.DataFrame)):
             # NOTE: `get_feature_names_out` requires sklearn >= 1.0
             categories = (
                 self.get_feature_names_out(X.cols(to_list=True))

--- a/test/transformer/sklearn/test_OneHotEncoder.py
+++ b/test/transformer/sklearn/test_OneHotEncoder.py
@@ -23,7 +23,7 @@ def test_return_dataframe_columns():
 
 
 def test_sparse_is_ture():
-    tf = OneHotEncoder(sparse=True)
+    tf = OneHotEncoder(sparse=True, sparse_output=True)
     result = tf.fit_transform(df_label)
 
     assert sparse.isspmatrix(result)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes https://github.com/Zeroto521/my-data-toolkit/actions/runs/3644331061/jobs/6153471919
- [x] whatsnew entry

The following logic doesn't compat with sklearn 1.2

https://github.com/Zeroto521/my-data-toolkit/blob/a250ea375a0605b9f61aa336b649d6282bd1fe27/dtoolkit/transformer/sklearn/OneHotEncoder.py#L128-L142
