### PR TITLE
ENH: `to_h3` supports return str (hexadecimal) format

### DIFF
--- a/dtoolkit/geoaccessor/geodataframe/to_h3.py
+++ b/dtoolkit/geoaccessor/geodataframe/to_h3.py
@@ -20,6 +20,7 @@ def to_h3(
     resolution: int,
     drop: bool = True,
     name: Hashable = "h3",
+    int_dtype: bool = True,
 ) -> pd.DataFrame | gpd.GeoDataFrame:
     """
     Convert Point to containing H3 cell index.
@@ -35,6 +36,9 @@ def to_h3(
     name : Hashable, default "h3"
         Name of the column to store the H3 cell index.
 
+    int_dtype : bool, default True
+        If True, use `h3.api.numpy_int` else use `h3.api.basic_str`.
+
     Returns
     -------
     DataFrame or GeoDataFrame
@@ -44,8 +48,10 @@ def to_h3(
     ------
     ModuleNotFoundError
         If don't have module named 'h3'.
+
     TypeError
         If the geometry is not Point.
+
     ValueError
         If the CRS is not WGS84 or EPSG:4326.
 
@@ -120,9 +126,17 @@ def to_h3(
         raise ValueError(f"Only support 'EPSG:4326' CRS, but got {df.crs!r}.")
 
     if all(df.geom_type == "Point"):
-        h3 = points_to_h3(df.geometry, resolution=resolution).rename(name)
+        h3 = points_to_h3(
+            df.geometry,
+            resolution=resolution,
+            int_dtype=int_dtype,
+        ).rename(name)
     elif all(df.geom_type == "Polygon"):
-        h3_list = polygons_to_h3(df.geometry, resolution=resolution)
+        h3_list = polygons_to_h3(
+            df.geometry,
+            resolution=resolution,
+            int_dtype=int_dtype,
+        )
         h3 = h3_list.explode().rename(name)
         df = repeat(df, s_len(h3_list))
     else:

--- a/dtoolkit/geoaccessor/geodataframe/to_h3.py
+++ b/dtoolkit/geoaccessor/geodataframe/to_h3.py
@@ -120,6 +120,18 @@ def to_h3(
     1     b  596540746614439935
     1     b  596538195403866111
     1     b  596541030082281471
+
+    Also support str (hexadecimal) format.
+
+    >>> df = pd.DataFrame({"x": [122, 100], "y": [55, 1]}).from_xy('x', 'y', crs=4326)
+    >>> df
+         x   y                    geometry
+    0  122  55  POINT (122.00000 55.00000)
+    1  100   1   POINT (100.00000 1.00000)
+    >>> df.to_h3(8, int_dtype=False)
+         x   y               h3
+    0  122  55  88143541bdfffff
+    1  100   1  886528b2a3fffff
     """
 
     if df.crs != 4326:

--- a/dtoolkit/geoaccessor/geoseries/to_h3.py
+++ b/dtoolkit/geoaccessor/geoseries/to_h3.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Callable
 from typing import Hashable
 
 import geopandas as gpd
@@ -19,6 +20,7 @@ def to_h3(
     resolution: int,
     drop: bool = True,
     name: Hashable = "h3",
+    enable_int: bool = True,
 ) -> pd.Series | gpd.GeoDataFrame:
     """
     Convert Point or Polygon to H3 cell index.
@@ -34,6 +36,9 @@ def to_h3(
 
     drop : bool, default True
         Whether to drop the geometry column.
+
+    enable_int : bool, default True
+        If True, use `h3.api.numpy_int` else use `h3.api.basic_str`.
 
     Returns
     -------
@@ -139,9 +144,9 @@ def to_h3(
         )
 
     if all(s.geom_type == "Point"):
-        h3 = points_to_h3(s, resolution=resolution)
+        h3 = points_to_h3(s, resolution=resolution, enable_int=enable_int)
     elif all(s.geom_type == "Polygon"):
-        h3_list = polygons_to_h3(s, resolution=resolution)
+        h3_list = polygons_to_h3(s, resolution=resolution, enable_int=enable_int)
         h3 = h3_list.explode()
         s = s.repeat(s_len(h3_list))
     else:
@@ -150,28 +155,20 @@ def to_h3(
     return h3 if drop else to_geoframe(h3.rename(name or s.name), geometry=s)
 
 
-def points_to_h3(s: gpd.GeoSeries, /, resolution: int) -> pd.Series:
+def points_to_h3(s: gpd.GeoSeries, /, resolution: int, enable_int: bool) -> pd.Series:
     # TODO: Use `latlon_to_h3` instead of `geo_to_h3`
     # While h3-py release 4, `latlon_to_h3` is not available.
-
-    # requires h3 >= 4
-    # from h3.api.numpy_int import latlng_to_cell
-    # requires h3 < 4
-    from h3.api.numpy_int import geo_to_h3
+    geo_to_h3 = method_from_h3("geo_to_h3", enable_int=enable_int)
 
     return xy(s, reverse=True, frame=False, name=None).apply(
         lambda yx: geo_to_h3(*yx, resolution),
     )
 
 
-def polygons_to_h3(s: gpd.GeoSeries, /, resolution: int) -> pd.Series:
+def polygons_to_h3(s: gpd.GeoSeries, /, resolution: int, enable_int: bool) -> pd.Series:
     # TODO: Use `polygon_to_cells` instead of `geo_to_h3`
     # While h3-py release 4, `polygon_to_cells` is not available.
-
-    # requires h3 >= 4
-    # from h3.api.numpy_int import polygon_to_cells
-    # requires h3 < 4
-    from h3.api.numpy_int import polyfill
+    polyfill = method_from_h3("polyfill", enable_int=enable_int)
 
     # If `geo_json_conformant` is True, the coordinate could be (lon, lat).
     return s_getattr(s, "__geo_interface__").apply(
@@ -179,3 +176,12 @@ def polygons_to_h3(s: gpd.GeoSeries, /, resolution: int) -> pd.Series:
         res=resolution,
         geo_json_conformant=True,
     )
+
+
+def method_from_h3(method: str, enable_int: bool = True) -> Callable:
+    if enable_int:
+        import h3.api.numpy_int as h3
+    else:
+        import h3.api.basic_int as h3
+
+    return getattr(h3, method)

--- a/dtoolkit/geoaccessor/geoseries/to_h3.py
+++ b/dtoolkit/geoaccessor/geoseries/to_h3.py
@@ -20,7 +20,7 @@ def to_h3(
     resolution: int,
     drop: bool = True,
     name: Hashable = "h3",
-    enable_int: bool = True,
+    int_dtype: bool = True,
 ) -> pd.Series | gpd.GeoDataFrame:
     """
     Convert Point or Polygon to H3 cell index.
@@ -37,7 +37,7 @@ def to_h3(
     drop : bool, default True
         Whether to drop the geometry column.
 
-    enable_int : bool, default True
+    int_dtype : bool, default True
         If True, use `h3.api.numpy_int` else use `h3.api.basic_str`.
 
     Returns
@@ -124,6 +124,23 @@ def to_h3(
     1    596538195403866111
     1    596541030082281471
     dtype: object
+
+    Also support str (hexadecimal) format.
+
+    >>> s = pd.Series(
+    ...     [
+    ...         "POINT (122 55)",
+    ...         "POINT (100 1)",
+    ...     ],
+    ... ).from_wkt(crs=4326, drop=True)
+    >>> s
+    0    POINT (122.00000 55.00000)
+    1     POINT (100.00000 1.00000)
+    dtype: geometry
+    >>> s.to_h3(8, int_dtype=False)
+    0    88143541bdfffff
+    1    886528b2a3fffff
+    dtype: object
     """
 
     # TODO: Advices for h3-pandas
@@ -144,9 +161,9 @@ def to_h3(
         )
 
     if all(s.geom_type == "Point"):
-        h3 = points_to_h3(s, resolution=resolution, enable_int=enable_int)
+        h3 = points_to_h3(s, resolution=resolution, int_dtype=int_dtype)
     elif all(s.geom_type == "Polygon"):
-        h3_list = polygons_to_h3(s, resolution=resolution, enable_int=enable_int)
+        h3_list = polygons_to_h3(s, resolution=resolution, int_dtype=int_dtype)
         h3 = h3_list.explode()
         s = s.repeat(s_len(h3_list))
     else:
@@ -155,20 +172,20 @@ def to_h3(
     return h3 if drop else to_geoframe(h3.rename(name or s.name), geometry=s)
 
 
-def points_to_h3(s: gpd.GeoSeries, /, resolution: int, enable_int: bool) -> pd.Series:
+def points_to_h3(s: gpd.GeoSeries, /, resolution: int, int_dtype: bool) -> pd.Series:
     # TODO: Use `latlon_to_h3` instead of `geo_to_h3`
     # While h3-py release 4, `latlon_to_h3` is not available.
-    geo_to_h3 = method_from_h3("geo_to_h3", enable_int=enable_int)
+    geo_to_h3 = method_from_h3("geo_to_h3", int_dtype=int_dtype)
 
     return xy(s, reverse=True, frame=False, name=None).apply(
         lambda yx: geo_to_h3(*yx, resolution),
     )
 
 
-def polygons_to_h3(s: gpd.GeoSeries, /, resolution: int, enable_int: bool) -> pd.Series:
+def polygons_to_h3(s: gpd.GeoSeries, /, resolution: int, int_dtype: bool) -> pd.Series:
     # TODO: Use `polygon_to_cells` instead of `geo_to_h3`
     # While h3-py release 4, `polygon_to_cells` is not available.
-    polyfill = method_from_h3("polyfill", enable_int=enable_int)
+    polyfill = method_from_h3("polyfill", int_dtype=int_dtype)
 
     # If `geo_json_conformant` is True, the coordinate could be (lon, lat).
     return s_getattr(s, "__geo_interface__").apply(
@@ -178,10 +195,10 @@ def polygons_to_h3(s: gpd.GeoSeries, /, resolution: int, enable_int: bool) -> pd
     )
 
 
-def method_from_h3(method: str, enable_int: bool = True) -> Callable:
-    if enable_int:
+def method_from_h3(method: str, int_dtype: bool = True) -> Callable:
+    if int_dtype:
         import h3.api.numpy_int as h3
     else:
-        import h3.api.basic_int as h3
+        import h3.api.basic_str as h3
 
     return getattr(h3, method)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

```python
    >>> import dtoolkit.geoaccessor
    >>> import pandas as pd
    >>> s = pd.Series(
    ...     [
    ...         "POINT (122 55)",
    ...         "POINT (100 1)",
    ...     ],
    ... ).from_wkt(crs=4326, drop=True)
    >>> s
    0    POINT (122.00000 55.00000)
    1     POINT (100.00000 1.00000)
    dtype: geometry
    >>> s.to_h3(8, int_dtype=False)
    0    88143541bdfffff
    1    886528b2a3fffff
    dtype: object
```