### PR TITLE
ENH: New accessor for Index `len`

### DIFF
--- a/doc/source/reference/accessor/index.rst
+++ b/doc/source/reference/accessor/index.rst
@@ -4,6 +4,14 @@ Index Accessor
 .. currentmodule:: dtoolkit.accessor.index
 
 
+General methods and attributes
+------------------------------
+.. autosummary::
+    :toctree: ../api/
+
+    len
+
+
 Conversion
 ----------
 .. autosummary::

--- a/dtoolkit/accessor/index/__init__.py
+++ b/dtoolkit/accessor/index/__init__.py
@@ -1,1 +1,2 @@
+from dtoolkit.accessor.index.len import len  # noqa: F401
 from dtoolkit.accessor.index.to_set import to_set  # noqa: F401

--- a/dtoolkit/accessor/index/len.py
+++ b/dtoolkit/accessor/index/len.py
@@ -47,12 +47,12 @@ def len(index: pd.Index, /, number: int = 1, other: int = None) -> pd.Index:
     >>> index = pd.Index([0, 1.5, "str", ("tuple",), ["list"], {}, object])
     >>> index
     Index([0, 1.5, 'str', ('tuple',), ['list'], {}, <class 'object'>], dtype='object')
-    >>> s.len()
+    >>> index.len()
     Float64Index([1.0, 1.0, 3.0, 1.0, 1.0, 0.0, nan], dtype='float64')
 
     Set `number` and `other` default return.
 
-    >>> s.len(number=0, other=0)
+    >>> index.len(number=0, other=0)
     Int64Index([0, 0, 3, 1, 1, 0, 0], dtype='int64')
     """
 

--- a/dtoolkit/accessor/index/len.py
+++ b/dtoolkit/accessor/index/len.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from functools import partial
+
+import pandas as pd
+from pandas.api.types import is_number
+
+from dtoolkit.accessor.register import register_index_method
+
+
+@register_index_method
+def len(index: pd.Index, /, number: int = 1, other: int = None) -> pd.Index:
+    """
+    Return the length of each element in the series.
+
+    Equals to ``s.apply(len)``, but the length of ``number`` type will as ``1``,
+    the length of other types will as ``NaN``.
+
+    Parameters
+    ----------
+    number : int, default 1
+        The default length of `number` type.
+
+    other : int or None, default None
+        The default length of `other` type.
+
+    Returns
+    -------
+    Index(int64)
+
+    See Also
+    --------
+    dtoolkit.accessor.series.len
+
+    Notes
+    -----
+    - To keep the Python naming style, so use this accessor via ``Index.len``
+      rather than ``Index.lens``.
+
+    - Different to :meth:`pandas.Index.str.len`. It only returns
+      :class:`collections.abc.Iterable` type length. Other type will return `NaN`.
+
+    Examples
+    --------
+    >>> import dtoolkit
+    >>> import pandas as pd
+    >>> index = pd.Index([0, 1.5, "str", ("tuple",), ["list"], {}, object])
+    >>> index
+    Index([0, 1.5, 'str', ('tuple',), ['list'], {}, <class 'object'>], dtype='object')
+    >>> s.len()
+    Float64Index([1.0, 1.0, 3.0, 1.0, 1.0, 0.0, nan], dtype='float64')
+
+    Set `number` and `other` default return.
+
+    >>> s.len(number=0, other=0)
+    Int64Index([0, 0, 3, 1, 1, 0, 0], dtype='int64')
+    """
+
+    return index.map(partial(length, number=number, other=other))
+
+
+def length(x, number: int, other: int | None) -> int | None:
+    if hasattr(x, "__len__"):
+        return x.__len__()
+    elif is_number(x):
+        return number
+
+    return other

--- a/dtoolkit/accessor/index/len.py
+++ b/dtoolkit/accessor/index/len.py
@@ -11,9 +11,9 @@ from dtoolkit.accessor.register import register_index_method
 @register_index_method
 def len(index: pd.Index, /, number: int = 1, other: int = None) -> pd.Index:
     """
-    Return the length of each element in the series.
+    Return the length of each element in the Index.
 
-    Equals to ``s.apply(len)``, but the length of ``number`` type will as ``1``,
+    Equals to ``index.map(len)``, but the length of ``number`` type will as ``1``,
     the length of other types will as ``NaN``.
 
     Parameters

--- a/dtoolkit/accessor/series/len.py
+++ b/dtoolkit/accessor/series/len.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 import pandas as pd
-from pandas.api.types import is_number
 
+from dtoolkit.accessor.index.len import length
 from dtoolkit.accessor.register import register_series_method
 
 
@@ -26,10 +24,14 @@ def len(s: pd.Series, /, number: int = 1, other: int = None) -> pd.Series:
     -------
     Series(int64)
 
+    See Also
+    --------
+    dtoolkit.accessor.index.len
+
     Notes
     -----
-    - To keep the Python naming style, so use this accessor via
-      ``Series.len`` rather than ``Series.lens``.
+    - To keep the Python naming style, so use this accessor via ``Series.len``
+      rather than ``Series.lens``.
 
     - Different to :meth:`pandas.Series.str.len`. It only returns
       :class:`collections.abc.Iterable` type length. Other type will return `NaN`.
@@ -74,13 +76,5 @@ def len(s: pd.Series, /, number: int = 1, other: int = None) -> pd.Series:
     dtype: int64
     """
 
-    return s.apply(_wrap_len, number=number, other=other)
+    return s.apply(length, number=number, other=other)
 
-
-def _wrap_len(x, number: int, other: int | None) -> int | None:
-    if hasattr(x, "__len__"):
-        return x.__len__()
-    elif is_number(x):
-        return number
-
-    return other

--- a/dtoolkit/accessor/series/len.py
+++ b/dtoolkit/accessor/series/len.py
@@ -77,4 +77,3 @@ def len(s: pd.Series, /, number: int = 1, other: int = None) -> pd.Series:
     """
 
     return s.apply(length, number=number, other=other)
-

--- a/dtoolkit/accessor/series/len.py
+++ b/dtoolkit/accessor/series/len.py
@@ -7,7 +7,7 @@ from dtoolkit.accessor.register import register_series_method
 @register_series_method
 def len(s: pd.Series, /, number: int = 1, other: int = None) -> pd.Series:
     """
-    Return the length of each element in the series.
+    Return the length of each element in the Series.
 
     Equals to ``s.apply(len)``, but the length of ``number`` type will as ``1``,
     the length of other types will as ``NaN``.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

Similar to `Series.len` accessor

```python
    >>> import dtoolkit
    >>> import pandas as pd
    >>> index = pd.Index([0, 1.5, "str", ("tuple",), ["list"], {}, object])
    >>> index
    Index([0, 1.5, 'str', ('tuple',), ['list'], {}, <class 'object'>], dtype='object')
    >>> index.len()
    Float64Index([1.0, 1.0, 3.0, 1.0, 1.0, 0.0, nan], dtype='float64')
```