### PR TITLE
ENH: New geoaccessor `geocentroid` to get the center point of points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 0.0.20] (2023-1-x)
+## [Version 0.0.20] (2022-12-30)
 
 Highlights of this release:
 
@@ -57,10 +57,10 @@ New features and improvements:
 
 Small bug-fix:
 
-- {pr}`822`: {meth}`~dtoolkit.geoaccessor.dataframe.to_geoframe` supports replacing old geometry.
-- {pr}`824`: Fix inputting `GeoDataFrame` but {meth}`~dtoolkit.accessor.dataframe.repeat` return `DataFrame`.
 - {pr}`780`: Fix {meth}`~dtoolkit.geoaccessor.dataframe.to_geoframe`'s geometry is `GeoSeries`.
 - {pr}`816`: Fix {meth}`~dtoolkit.geoaccessor.dataframe.to_geoframe` result CRS is missing.
+- {pr}`822`: {meth}`~dtoolkit.geoaccessor.dataframe.to_geoframe` supports replacing old geometry.
+- {pr}`824`: Fix inputting `GeoDataFrame` but {meth}`~dtoolkit.accessor.dataframe.repeat` return `DataFrame`.
 
 API changes:
 

--- a/doc/source/reference/geoaccessor/geodataframe.rst
+++ b/doc/source/reference/geoaccessor/geodataframe.rst
@@ -15,6 +15,7 @@ General methods and attributes
     geodistance
     geodistance_matrix
     geobuffer
+    geocentroid
     coordinates
     count_coordinates
     has_hole

--- a/doc/source/reference/geoaccessor/geoseries.rst
+++ b/doc/source/reference/geoaccessor/geoseries.rst
@@ -15,6 +15,7 @@ General methods and attributes
     geodistance
     geodistance_matrix
     geobuffer
+    geocentroid
     coordinates
     count_coordinates
     has_hole

--- a/dtoolkit/geoaccessor/geodataframe/__init__.py
+++ b/dtoolkit/geoaccessor/geodataframe/__init__.py
@@ -18,6 +18,7 @@ from dtoolkit.geoaccessor.geodataframe.filter_geometry import (  # noqa: F401
 )
 from dtoolkit.geoaccessor.geodataframe.geoarea import geoarea  # noqa: F401
 from dtoolkit.geoaccessor.geodataframe.geobuffer import geobuffer  # noqa: F401
+from dtoolkit.geoaccessor.geodataframe.geocentroid import geocentroid  # noqa: F401
 from dtoolkit.geoaccessor.geodataframe.geodistance import geodistance  # noqa: F401
 from dtoolkit.geoaccessor.geodataframe.geodistance_matrix import (  # noqa: F401
     geodistance_matrix,

--- a/dtoolkit/geoaccessor/geodataframe/geocentroid.py
+++ b/dtoolkit/geoaccessor/geodataframe/geocentroid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Hashable
 
 import geopandas as gpd
+import pandas as pd
 from pandas.util._decorators import doc
 from shapely import Point
 

--- a/dtoolkit/geoaccessor/geodataframe/geocentroid.py
+++ b/dtoolkit/geoaccessor/geodataframe/geocentroid.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Hashable
+
 import geopandas as gpd
 from pandas.util._decorators import doc
 from shapely import Point
@@ -11,8 +15,11 @@ from dtoolkit.geoaccessor.register import register_geodataframe_method
 def geocentroid(
     df: gpd.GeoDataFrame,
     /,
-    max_iter: int = 500,
-    tol: float = 1e-5,
+    weights: Hashable | pd.Series = None,
+    max_iter: int = 300,
+    tol: float = 1e-4,
 ) -> Point:
+    if weights is not None and isinstance(weights, Hashable):
+        weights = df[weights]
 
-    return s_geocentroid(df.geometry, max_iter=max_iter, tol=tol)
+    return s_geocentroid(df.geometry, weights=weights, max_iter=max_iter, tol=tol)

--- a/dtoolkit/geoaccessor/geodataframe/geocentroid.py
+++ b/dtoolkit/geoaccessor/geodataframe/geocentroid.py
@@ -1,0 +1,18 @@
+import geopandas as gpd
+from pandas.util._decorators import doc
+from shapely import Point
+
+from dtoolkit.geoaccessor.geoseries import geocentroid as s_geocentroid
+from dtoolkit.geoaccessor.register import register_geodataframe_method
+
+
+@register_geodataframe_method
+@doc(s_geocentroid)
+def geocentroid(
+    df: gpd.GeoDataFrame,
+    /,
+    max_iter: int = 500,
+    tol: float = 1e-5,
+) -> Point:
+
+    return s_geocentroid(df.geometry, max_iter=max_iter, tol=tol)

--- a/dtoolkit/geoaccessor/geoseries/__init__.py
+++ b/dtoolkit/geoaccessor/geoseries/__init__.py
@@ -15,6 +15,7 @@ from dtoolkit.geoaccessor.geoseries.duplicated_geometry_groups import (  # noqa:
 from dtoolkit.geoaccessor.geoseries.filter_geometry import filter_geometry  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.geoarea import geoarea  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.geobuffer import geobuffer  # noqa: F401
+from dtoolkit.geoaccessor.geoseries.geocentroid import geocentroid  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.geodistance import geodistance  # noqa: F401
 from dtoolkit.geoaccessor.geoseries.geodistance_matrix import (  # noqa: F401
     geodistance_matrix,

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -31,6 +31,10 @@ def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 500, tol: float = 1e-5) -> 
     TypeError
         If the geometry is not a Point.
 
+    See Also
+    --------
+    geopandas.GeoSeries.centroid
+
     Examples
     --------
     >>> import dtoolkit.geoaccessor

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -1,6 +1,6 @@
 import geopandas as gpd
-
 from shapely import Point
+
 from dtoolkit.geoaccessor.geoseries.geodistance import geodistance
 from dtoolkit.geoaccessor.geoseries.xy import xy
 from dtoolkit.geoaccessor.register import register_geoseries_method

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -1,0 +1,26 @@
+import geopandas as gpd
+
+from shapely import Point
+from dtoolkit.geoaccessor.geoseries.geodistance import geodistance
+from dtoolkit.geoaccessor.geoseries.xy import xy
+from dtoolkit.geoaccessor.register import register_geoseries_method
+
+
+@register_geoseries_method
+def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 300, tol: float = 1e-4) -> Point:
+    if s.crs != 4326:
+        raise ValueError(f"Only support 'EPSG:4326' CRS, but got {s.crs!r}.")
+    if not all(s.geom_type == "Point"):
+        raise TypeError("Only support 'Point' geometry type.")
+
+    coord = xy(s)
+    x, y = coord.mean().tolist()
+    for _ in range(max_iter):
+        dis = geodistance(s, Point(x, y))
+        x_, y_ = (coord.mul(dis, axis=0).sum() / dis.sum()).tolist()
+
+        if abs(x - x_) <= tol and abs(y - y_) <= tol:
+            break
+        x, y = x_, y_
+
+    return Point(x, y)

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -7,7 +7,52 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 300, tol: float = 1e-4) -> Point:
+def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 500, tol: float = 1e-5) -> Point:
+    """
+    Return the centroid of all points.
+
+    Parameters
+    ----------
+    max_iter : int, default 500
+        Maximum number of iterations to perform.
+
+    tol : float, default 1e-5
+        Tolerance for convergence.
+
+    Returns
+    -------
+    Point
+
+    Raises
+    ------
+    ValueError
+        If the CRS is not ``ESGP:4326``.
+
+    TypeError
+        If the geometry is not a Point.
+
+    Examples
+    --------
+    >>> import dtoolkit.geoaccessor
+    >>> import geopandas as gpd
+    >>> from shapely import Point
+    >>> df = gpd.GeoDataFrame(
+    ...     geometry=[
+    ...         Point(100, 32),
+    ...         Point(120, 50),
+    ...         Point(122, 55)
+    ...     ],
+    ...     crs=4326,
+    ... )
+    >>> df
+                         geometry
+    0  POINT (100.00000 32.00000)
+    1  POINT (120.00000 50.00000)
+    2  POINT (122.00000 55.00000)
+    >>> df.geocentroid()
+    <POINT (112.213 44.119)>
+    """
+
     if s.crs != 4326:
         raise ValueError(f"Only support 'EPSG:4326' CRS, but got {s.crs!r}.")
     if not all(s.geom_type == "Point"):
@@ -20,6 +65,7 @@ def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 300, tol: float = 1e-4) -> 
         Xt = coord.mul(dis, axis=0).sum() / dis.sum()
 
         if ((X - Xt).abs() <= tol).all():
+            X = Xt
             break
 
         X = Xt

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -44,6 +44,8 @@ def geocentroid(
     See Also
     --------
     geopandas.GeoSeries.centroid
+    dtoolkit.geoaccessor.geoseries.geocentroid
+    dtoolkit.geoaccessor.geodataframe.geocentroid
 
     Examples
     --------

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -14,13 +14,14 @@ def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 300, tol: float = 1e-4) -> 
         raise TypeError("Only support 'Point' geometry type.")
 
     coord = xy(s)
-    x, y = coord.mean().tolist()
+    X = coord.mean()
     for _ in range(max_iter):
-        dis = geodistance(s, Point(x, y))
-        x_, y_ = (coord.mul(dis, axis=0).sum() / dis.sum()).tolist()
+        dis = geodistance(s, Point(*X.tolist()))
+        Xt = coord.mul(dis, axis=0).sum() / dis.sum()
 
-        if abs(x - x_) <= tol and abs(y - y_) <= tol:
+        if ((X - Xt).abs() <= tol).all():
             break
-        x, y = x_, y_
 
-    return Point(x, y)
+        X = Xt
+
+    return Point(*X.tolist())

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -41,9 +41,6 @@ def geocentroid(
     ValueError
         If the CRS is not ``ESGP:4326``.
 
-    TypeError
-        If the geometry is not a Point.
-
     See Also
     --------
     geopandas.GeoSeries.centroid
@@ -78,8 +75,6 @@ def geocentroid(
 
     if s.crs != 4326:
         raise ValueError(f"Only support 'EPSG:4326' CRS, but got {s.crs!r}.")
-    if not all(s.geom_type == "Point"):
-        raise TypeError("Only support 'Point' geometry type.")
 
     weights = np.asarray(weights) if weights is not None else 1
     coord = xy(s)

--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -1,4 +1,6 @@
 import geopandas as gpd
+import numpy as np
+import pandas as pd
 from shapely import Point
 
 from dtoolkit.geoaccessor.geoseries.geodistance import geodistance
@@ -7,16 +9,27 @@ from dtoolkit.geoaccessor.register import register_geoseries_method
 
 
 @register_geoseries_method
-def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 500, tol: float = 1e-5) -> Point:
+def geocentroid(
+    s: gpd.GeoSeries,
+    /,
+    weights: pd.Series = None,
+    max_iter: int = 300,
+    tol: float = 1e-4,
+) -> Point:
     """
-    Return the centroid of all points.
+    Return the centroid of all points via the center of gravity method.
 
     Parameters
     ----------
-    max_iter : int, default 500
+    weights : Hashable or 1d array-like, optional
+        - None : All weights will be set to 1.
+        - Hashable : Only for DataFrame, the column name.
+        - 1d array-like : The weights of each point.
+
+    max_iter : int, default 300
         Maximum number of iterations to perform.
 
-    tol : float, default 1e-5
+    tol : float, default 1e-4
         Tolerance for convergence.
 
     Returns
@@ -41,20 +54,26 @@ def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 500, tol: float = 1e-5) -> 
     >>> import geopandas as gpd
     >>> from shapely import Point
     >>> df = gpd.GeoDataFrame(
-    ...     geometry=[
-    ...         Point(100, 32),
-    ...         Point(120, 50),
-    ...         Point(122, 55)
-    ...     ],
+    ...     {
+    ...         "weights": [1, 2, 3],
+    ...         "geometry": [Point(100, 32), Point(120, 50), Point(122, 55)],
+    ...     },
     ...     crs=4326,
     ... )
     >>> df
-                         geometry
-    0  POINT (100.00000 32.00000)
-    1  POINT (120.00000 50.00000)
-    2  POINT (122.00000 55.00000)
+       weights                    geometry
+    0        1  POINT (100.00000 32.00000)
+    1        2  POINT (120.00000 50.00000)
+    2        3  POINT (122.00000 55.00000)
     >>> df.geocentroid()
-    <POINT (112.213 44.119)>
+    <POINT (112.375 44.276)>
+
+    Set weights for each point.
+
+    >>> df.geocentroid("weights")
+    <POINT (114.516 46.675)>
+    >>> df.geocentroid([1, 2, 3])
+    <POINT (114.516 46.675)>
     """
 
     if s.crs != 4326:
@@ -62,10 +81,11 @@ def geocentroid(s: gpd.GeoSeries, /, max_iter: int = 500, tol: float = 1e-5) -> 
     if not all(s.geom_type == "Point"):
         raise TypeError("Only support 'Point' geometry type.")
 
+    weights = np.asarray(weights) if weights is not None else 1
     coord = xy(s)
     X = coord.mean()
     for _ in range(max_iter):
-        dis = geodistance(s, Point(*X.tolist()))
+        dis = geodistance(s, Point(*X.tolist())).mul(weights, axis=0)
         Xt = coord.mul(dis, axis=0).sum() / dis.sum()
 
         if ((X - Xt).abs() <= tol).all():

--- a/test/geoaccessor/geoseries/test_geocentroid.py
+++ b/test/geoaccessor/geoseries/test_geocentroid.py
@@ -23,3 +23,10 @@ from dtoolkit.geoaccessor.geoseries import geocentroid
 def test_error(s, error):
     with pytest.raises(error):
         geocentroid(s)
+
+
+def test_work():
+    # test `tol` parameter
+    result = gpd.GeoSeries([Point(100, 50), Point(120, 50)], crs=4326).geocentroid()
+
+    assert result.equals(Point(110, 50))

--- a/test/geoaccessor/geoseries/test_geocentroid.py
+++ b/test/geoaccessor/geoseries/test_geocentroid.py
@@ -1,7 +1,6 @@
 import geopandas as gpd
-from shapely import Point
-
 import pytest
+from shapely import Point
 
 from dtoolkit.geoaccessor.geoseries import geocentroid
 

--- a/test/geoaccessor/geoseries/test_geocentroid.py
+++ b/test/geoaccessor/geoseries/test_geocentroid.py
@@ -1,0 +1,26 @@
+import geopandas as gpd
+from shapely import Point
+
+import pytest
+
+from dtoolkit.geoaccessor.geoseries import geocentroid
+
+
+@pytest.mark.parametrize(
+    "s, error",
+    [
+        (
+            gpd.GeoSeries(
+                [
+                    Point(100, 32),
+                    Point(120, 50),
+                    Point(122, 55),
+                ]
+            ),
+            ValueError,
+        ),
+    ],
+)
+def test_error(s, error):
+    with pytest.raises(error):
+        geocentroid(s)

--- a/test/geoaccessor/geoseries/test_geocentroid.py
+++ b/test/geoaccessor/geoseries/test_geocentroid.py
@@ -25,7 +25,7 @@ def test_error(s, error):
         geocentroid(s)
 
 
-def test_work():
+def test_tol():
     # test `tol` parameter
     result = gpd.GeoSeries([Point(100, 50), Point(120, 50)], crs=4326).geocentroid()
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

```python
    >>> import dtoolkit.geoaccessor
    >>> import geopandas as gpd
    >>> from shapely import Point
    >>> df = gpd.GeoDataFrame(
    ...     geometry=[
    ...         Point(100, 32),
    ...         Point(120, 50),
    ...         Point(122, 55)
    ...     ],
    ...     crs=4326,
    ... )
    >>> df
                         geometry
    0  POINT (100.00000 32.00000)
    1  POINT (120.00000 50.00000)
    2  POINT (122.00000 55.00000)
    >>> df.geocentroid()
    <POINT (112.213 44.119)>
```