### PR TITLE
BUG: `geocentroid` should support one point condition

### DIFF
--- a/dtoolkit/geoaccessor/geoseries/geocentroid.py
+++ b/dtoolkit/geoaccessor/geoseries/geocentroid.py
@@ -80,11 +80,15 @@ def geocentroid(
     <POINT (121.999 54.999)>
     """
 
-    weights = np.asarray(weights) if weights is not None else 1
     coord = xy(s)
+    if len(coord) == 1:
+        return Point(coord.iloc[0])
+
+    weights = np.asarray(weights) if weights is not None else 1
     X = coord.mul(weights, axis=0).mean()
+
     for _ in range(max_iter):
-        dis = geodistance(s, Point(*X.tolist())).rdiv(1).mul(weights, axis=0)
+        dis = geodistance(s, Point(X)).rdiv(1).mul(weights, axis=0)
         Xt = coord.mul(dis, axis=0).sum() / dis.sum()
 
         if ((X - Xt).abs() <= tol).all():
@@ -93,4 +97,4 @@ def geocentroid(
 
         X = Xt
 
-    return Point(*X.tolist())
+    return Point(X)

--- a/test/geoaccessor/geoseries/test_geocentroid.py
+++ b/test/geoaccessor/geoseries/test_geocentroid.py
@@ -1,0 +1,10 @@
+import geopandas as gpd
+from shapely import Point
+
+from dtoolkit.geoaccessor.geoseries import geocentroid
+
+
+def test_one_point():
+    s = gpd.GeoSeries(Point(100, 32), crs=4326)
+
+    assert s.geocentroid() == Point(100, 32)

--- a/test/geoaccessor/geoseries/test_geocentroid.py
+++ b/test/geoaccessor/geoseries/test_geocentroid.py
@@ -7,4 +7,4 @@ from dtoolkit.geoaccessor.geoseries import geocentroid
 def test_one_point():
     s = gpd.GeoSeries(Point(100, 32), crs=4326)
 
-    assert s.geocentroid() == Point(100, 32)
+    assert geocentroid(s) == Point(100, 32)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #834
- [x] whatsnew entry

```python
import dtoolkit.geoaccessor
import geopandas as gpd
from shapely import Point

df = gpd.GeoDataFrame(
    {
        "weights": [1, 2, 3],
        "geometry": [Point(100, 32), Point(120, 50), Point(122, 55)],
    },
    crs=4326,
)

df.groupby('weights').apply(lambda df: df.geocentroid())
```

```python
Traceback (most recent call last):
  File "C:\Users\Zero\Documents\GitHub\my-data-toolkit\temp.py", line 11, in <module>
    print(df.geocentroid())
  File "C:\Users\Zero\Documents\GitHub\my-data-toolkit\dtoolkit\accessor\register.py", line 41, in wrapper
    return method(pd_obj, *args, **kwargs)
  File "C:\Users\Zero\Documents\GitHub\my-data-toolkit\dtoolkit\geoaccessor\geodataframe\geocentroid.py", line 26, in geocentroid
    return s_geocentroid(df.geometry, weights=weights, max_iter=max_iter, tol=tol)
  File "C:\Users\Zero\Documents\GitHub\my-data-toolkit\dtoolkit\geoaccessor\geoseries\geocentroid.py", line 87, in geocentroid
    dis = geodistance(s, Point(X.tolist()))
  File "C:\Users\Zero\Documents\GitHub\my-data-toolkit\dtoolkit\geoaccessor\geoseries\geodistance.py", line 120, in geodistance
    x2, y2 = other.x, other.y
  File "C:\Software\miniforge3\envs\dtoolkit\lib\site-packages\shapely\geometry\point.py", line 83, in x
    return shapely.get_x(self)
  File "C:\Software\miniforge3\envs\dtoolkit\lib\site-packages\shapely\decorators.py", line 77, in wrapped
    return func(*args, **kwargs)
  File "C:\Software\miniforge3\envs\dtoolkit\lib\site-packages\shapely\_geometry.py", line 271, in get_x
    return lib.get_x(point, **kwargs)
shapely.errors.GEOSException: UnsupportedOperationException: getX called on empty Point
```