### PR TITLE
MAINT: Added `textdistance*` support `nan` and `None`

### DIFF
--- a/dtoolkit/accessor/series/textdistance.py
+++ b/dtoolkit/accessor/series/textdistance.py
@@ -5,7 +5,6 @@ from typing import Callable
 from warnings import warn
 
 import pandas as pd
-from pandas.api.types import is_string_dtype
 
 from dtoolkit.accessor.register import register_series_method
 from dtoolkit.util._exception import find_stack_level
@@ -66,7 +65,7 @@ def textdistance(
 
     Notes
     -----
-    Doesn't support to compare `None` or `nan` value.
+    The result of comparing to None or nan value is depended on the ``method``.
 
     Examples
     --------
@@ -87,20 +86,14 @@ def textdistance(
     dtype: float64
     """
 
-    if not is_string_dtype(s):
-        raise TypeError(f"Expected string dtype, but got {s.dtype!r}.")
-
     if method is None:
         method = __import__("rapidfuzz").fuzz.ratio
     method = lru_cache(method)
 
-    if isinstance(other, str):
+    if isinstance(other, str) or pd.isna(other):
         return s.apply(method, args=(other,), **kwargs)
 
     elif isinstance(other, pd.Series):
-        if not is_string_dtype(other):
-            raise TypeError(f"Expected Series(string), but got {other.dtype!r}.")
-
         if align and not s.index.equals(other.index):
             warn("The indices are different.", stacklevel=find_stack_level())
             s, other = s.align(other)

--- a/dtoolkit/accessor/series/textdistance.py
+++ b/dtoolkit/accessor/series/textdistance.py
@@ -5,6 +5,7 @@ from typing import Callable
 from warnings import warn
 
 import pandas as pd
+from pandas.api.types import is_list_like
 
 from dtoolkit.accessor.register import register_series_method
 from dtoolkit.util._exception import find_stack_level
@@ -88,7 +89,11 @@ def textdistance(
         method = __import__("rapidfuzz").fuzz.ratio
     method = lru_cache(method)
 
-    if isinstance(other, str) or pd.isna(other):
+    if (
+        isinstance(other, str)
+        or other is None
+        or (not is_list_like(other) and pd.isna(other))
+    ):
         return s.apply(method, args=(other,), **kwargs)
 
     elif isinstance(other, pd.Series):

--- a/dtoolkit/accessor/series/textdistance_matrix.py
+++ b/dtoolkit/accessor/series/textdistance_matrix.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Callable
 
 import pandas as pd
-from pandas.api.types import is_string_dtype
 
 from dtoolkit.accessor.register import register_series_method
 
@@ -57,7 +56,7 @@ def textdistance_matrix(
 
     Notes
     -----
-    Doesn't support to compare `None` or `nan` value.
+    The result of comparing to None or nan value is depended on the ``method``.
 
     Examples
     --------
@@ -72,13 +71,6 @@ def textdistance_matrix(
            0          1
     0  100.0  36.363636
     1   20.0  18.181818
-
-    Convert `nan` / `None` to `""` empty string before getting distance.
-
-    >>> s.textdistance_matrix(pd.Series(["hello", None, float("nan")]).fillna(""))
-           0    1    2
-    0  100.0  0.0  0.0
-    1   20.0  0.0  0.0
     """
     from rapidfuzz.process import cdist
 
@@ -89,8 +81,6 @@ def textdistance_matrix(
         other = s.copy()
     if not isinstance(other, pd.Series):
         raise TypeError(f"Expected Series(string), but got {type(other).__name__!r}.")
-    if not is_string_dtype(other):
-        raise TypeError(f"Expected Series(string), but got {other.dtype!r}.")
 
     return pd.DataFrame(
         cdist(s, other, scorer=method, workers=-1, **kwargs),

--- a/dtoolkit/geoaccessor/geoseries/toposimplify.py
+++ b/dtoolkit/geoaccessor/geoseries/toposimplify.py
@@ -36,6 +36,7 @@ def toposimplify(
 
     simplify_algorithm : {{'dp', 'vw'}}, default 'dp'
         ``vw`` will only be selected if ``simplify_with`` is set to ``simplification``.
+
             - ``dp`` : Douglas-Peucker
             - ``vw`` : Visvalingam-Whyatt
 

--- a/test/accessor/series/test_textdistance.py
+++ b/test/accessor/series/test_textdistance.py
@@ -100,6 +100,33 @@ def test_error(s, other, align, error):
             rapidfuzz.string_metric.levenshtein,
             pd.Series([2, 6]),
         ),
+        # test None and nan
+        # NOTE: requires rapidfuzz >= 3.x
+        (
+            pd.Series(["hi", "python", None, None, float("nan"), "?"]),
+            pd.Series([None, float("nan"), None, float("nan"), float("nan"), "!"]),
+            True,
+            None,
+            pd.Series([0] * 6),
+        ),
+        # test other is None
+        # NOTE: requires rapidfuzz >= 3.x
+        (
+            pd.Series(["hi", "python", None, None, float("nan"), "?"]),
+            None,
+            True,
+            None,
+            pd.Series([0] * 6),
+        ),
+        # test other is nan
+        # NOTE: requires rapidfuzz >= 3.x
+        (
+            pd.Series(["hi", "python", None, None, float("nan"), "?"]),
+            float("nan"),
+            True,
+            None,
+            pd.Series([0] * 6),
+        ),
     ],
 )
 def test_work(s, other, align, method, expected):

--- a/test/accessor/series/test_textdistance_matrix.py
+++ b/test/accessor/series/test_textdistance_matrix.py
@@ -39,7 +39,7 @@ rapidfuzz = pytest.importorskip("rapidfuzz")
         # other elements contain None or nan
         (
             pd.Series(["hello", "world", "!"]),
-            pd.Series(["hi!", None, float("nan")]).fillna(""),
+            pd.Series(["hi!", None, float("nan")]),
             None,
             pd.DataFrame([[25, 0, 0], [0, 0, 0], [50, 0, 0]]),
         ),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [ ] whatsnew entry
