### PR TITLE
API/DEP: Add `DeprecationWarning` for `xy` and `coordinates`

### DIFF
--- a/dtoolkit/geoaccessor/geodataframe/coordinates.py
+++ b/dtoolkit/geoaccessor/geodataframe/coordinates.py
@@ -6,7 +6,6 @@ from dtoolkit.geoaccessor.geoseries import coordinates as s_coordinates
 from dtoolkit.geoaccessor.register import register_geodataframe_method
 
 
-@register_geodataframe_method("get_coordinates")
 @register_geodataframe_method
 @doc(s_coordinates, klass="GeoDataFrame")
 def coordinates(df: gpd.GeoDataFrame, /, **kwargs) -> pd.Series:

--- a/dtoolkit/geoaccessor/geoseries/coordinates.py
+++ b/dtoolkit/geoaccessor/geoseries/coordinates.py
@@ -4,15 +4,27 @@ from pandas.util._decorators import doc
 from shapely import get_coordinates
 
 from dtoolkit.geoaccessor.register import register_geoseries_method
+from dtoolkit.util._decorator import warning
 
 
 @register_geoseries_method
 @doc(klass="GeoSeries")
+@warning(
+    "The 'coordinates' is deprecated and will be removed in 0.0.22. "
+    "Please use 'GeoSeries.get_coordinates' in geopandas 0.13 instead."
+    "(Warning added DToolKit 0.0.21)",
+    DeprecationWarning,
+    stacklevel=3,
+)
 def coordinates(s: gpd.GeoSeries, /, **kwargs) -> pd.Series:
     """
     Gets coordinates from each geometry of :class:`~geopandas.{klass}`.
 
     A sugary syntax wraps :meth:`shapely.get_coordinates`.
+
+    .. deprecated:: 0.0.22
+        The 'coordinates' is deprecated.
+        Please use 'GeoSeries.get_coordinates' in geopandas 0.13 instead.
 
     Parameters
     ----------

--- a/dtoolkit/geoaccessor/geoseries/xy.py
+++ b/dtoolkit/geoaccessor/geoseries/xy.py
@@ -7,9 +7,17 @@ import pandas as pd
 
 from dtoolkit._typing import SeriesOrFrame
 from dtoolkit.geoaccessor.register import register_geoseries_method
+from dtoolkit.util._decorator import warning
 
 
 @register_geoseries_method
+@warning(
+    "The 'coordinates' is deprecated and will be removed in 0.0.22. "
+    "Please use 'GeoSeries.get_coordinates' in geopandas 0.13 instead."
+    "(Warning added DToolKit 0.0.21)",
+    DeprecationWarning,
+    stacklevel=3,
+)
 def xy(
     s: gpd.GeoSeries,
     /,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoSeries.get_coordinates.html
- [x] whatsnew entry

`xy` and `coordinates` could be replaced by `get_coordinates` in geopandas 0.13
