### PR TITLE
TST: Repalce `warns` with `catch_warnings`

### DIFF
--- a/test/util/_decorator/test_warning.py
+++ b/test/util/_decorator/test_warning.py
@@ -20,7 +20,7 @@ def test_work(args, kwargs, message, exception):
     def func(*args, **kwargs):
         return dict(args=args, kwargs=kwargs)
 
-    with pytest.warns(exception, match=message):
+    with pytest.catch_warnings(exception, match=message):
         result = func(*args, **kwargs)
 
     assert isinstance(result, dict)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
- [ ] whatsnew entry
