### PR TITLE
MAINT: Compact pandas 2.x, ignore dtypes to pass testcases

### DIFF
--- a/test/accessor/dataframe/test_decompose.py
+++ b/test/accessor/dataframe/test_decompose.py
@@ -232,7 +232,7 @@ decomposition = pytest.importorskip("sklearn.decomposition")
 def test_work(df, method, columns, drop, kwargs, expected):
     result = df.decompose(method, columns, drop=drop, **kwargs)
 
-    assert_frame_equal(result, expected, check_dtype=False)
+    assert_frame_equal(result, expected, check_dtype=False, check_like=True)
 
 
 @pytest.mark.parametrize(

--- a/test/accessor/dataframe/test_fillna_regression.py
+++ b/test/accessor/dataframe/test_fillna_regression.py
@@ -276,7 +276,7 @@ tree = pytest.importorskip("sklearn.tree")
 def test_work(df, method, columns, how, kwargs, expected):
     result = df.fillna_regression(method, columns, how=how, **kwargs)
 
-    assert_frame_equal(result, expected, check_dtype=False)
+    assert_frame_equal(result, expected.astype(result.dtypes))
 
 
 def test_error():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [ ] closes #xxxx
- [x] whatsnew entry

To fix following testcases

```python
FAILED test/accessor/dataframe/test_decompose.py::test_work[df8-PCA-columns8-True-kwargs8-expected8] - AssertionError: DataFrame.columns are different

DataFrame.columns values are different (80.0 %)
[left]:  Index(['A', 'B', 'C', 'X', 'a'], dtype='object')
[right]: Index(['X', 'A', 'B', 'C', 'a'], dtype='object')
At positional index 0, first diff: A != X
FAILED test/accessor/dataframe/test_fillna_regression.py::test_work[df0-LinearRegression-columns0-na-kwargs0-expected0] - AssertionError: DataFrame.iloc[:, 2] (column name="y") are different

DataFrame.iloc[:, 2] (column name="y") values are different (20.0 %)
[index]: [0, 1, 2, 3, 4]
[left]:  [6.0, 8.0, 9.0, 11.0, 15.999999999999998]
[right]: [6, 8, 9, 11, 16]
```

`