### PR TITLE
MAINT: Import Hashable from collections.abc instead of typing

### DIFF
--- a/dtoolkit/accessor/dataframe/cols.py
+++ b/dtoolkit/accessor/dataframe/cols.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 

--- a/dtoolkit/accessor/dataframe/decompose.py
+++ b/dtoolkit/accessor/dataframe/decompose.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/dtoolkit/accessor/dataframe/drop_not_duplicates.py
+++ b/dtoolkit/accessor/dataframe/drop_not_duplicates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import Literal
 from typing import Sequence
 

--- a/dtoolkit/accessor/dataframe/expand.py
+++ b/dtoolkit/accessor/dataframe/expand.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from textwrap import dedent
 from collections.abc import Hashable
+from textwrap import dedent
 
 import pandas as pd
 from pandas.util._decorators import doc

--- a/dtoolkit/accessor/dataframe/expand.py
+++ b/dtoolkit/accessor/dataframe/expand.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 from pandas.util._decorators import doc

--- a/dtoolkit/accessor/dataframe/fillna_regression.py
+++ b/dtoolkit/accessor/dataframe/fillna_regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import Literal
 from typing import TYPE_CHECKING
 

--- a/dtoolkit/accessor/dataframe/filter_in.py
+++ b/dtoolkit/accessor/dataframe/filter_in.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import Iterable
 from typing import Literal
 

--- a/dtoolkit/accessor/dataframe/repeat.py
+++ b/dtoolkit/accessor/dataframe/repeat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 from pandas.api.types import is_number

--- a/dtoolkit/accessor/dataframe/to_series.py
+++ b/dtoolkit/accessor/dataframe/to_series.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 

--- a/dtoolkit/accessor/dataframe/to_zh.py
+++ b/dtoolkit/accessor/dataframe/to_zh.py
@@ -1,4 +1,4 @@
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 

--- a/dtoolkit/accessor/dataframe/values_to_dict.py
+++ b/dtoolkit/accessor/dataframe/values_to_dict.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 

--- a/dtoolkit/accessor/dataframe/weighted_mean.py
+++ b/dtoolkit/accessor/dataframe/weighted_mean.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 from pandas.api.types import is_dict_like

--- a/dtoolkit/accessor/index/to_set.py
+++ b/dtoolkit/accessor/index/to_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 

--- a/dtoolkit/accessor/series/cols.py
+++ b/dtoolkit/accessor/series/cols.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import pandas as pd
 

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import Hashable
+from collections.abc import Hashable
 from typing import Iterable
 
 import pandas as pd

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from textwrap import dedent
 from collections.abc import Hashable
+from textwrap import dedent
 from typing import Iterable
 
 import pandas as pd

--- a/dtoolkit/geoaccessor/dataframe/from_wkb.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkb.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/dataframe/from_wkt.py
+++ b/dtoolkit/geoaccessor/dataframe/from_wkt.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/dataframe/from_xy.py
+++ b/dtoolkit/geoaccessor/dataframe/from_xy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/dataframe/geocode.py
+++ b/dtoolkit/geoaccessor/dataframe/geocode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/dataframe/to_geoframe.py
+++ b/dtoolkit/geoaccessor/dataframe/to_geoframe.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/geodataframe/geobuffer.py
+++ b/dtoolkit/geoaccessor/geodataframe/geobuffer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import geopandas as gpd
 from pandas.util._decorators import doc

--- a/dtoolkit/geoaccessor/geodataframe/geocentroid.py
+++ b/dtoolkit/geoaccessor/geodataframe/geocentroid.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 
 import geopandas as gpd
 import pandas as pd

--- a/dtoolkit/geoaccessor/geodataframe/reverse_geocode.py
+++ b/dtoolkit/geoaccessor/geodataframe/reverse_geocode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/geoseries/reverse_geocode.py
+++ b/dtoolkit/geoaccessor/geoseries/reverse_geocode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd

--- a/dtoolkit/geoaccessor/series/geocode.py
+++ b/dtoolkit/geoaccessor/series/geocode.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Hashable
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import geopandas as gpd


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/deprecated-class.html
- [x] Replaced all imports of `Hashable` from the typing module with imports from `collections.abc` for compatibility with newer Python versions.
