### PR TITLE
BUG: Fix `expand` to return DataFrame for single-element iterables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
 
-      - uses: mamba-org/setup-micromamba@v1.9.0
+      - uses: mamba-org/setup-micromamba@v2.0.5
         with:
           environment-file: ${{ matrix.env }}
           create-args: python=${{ matrix.python-version }}

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -111,13 +111,14 @@ def expand(
     """
 
     s_list = s.apply(_wrap_collapse, flatten=flatten)
-    if all(s_len := s_list.len() == 1):
+    if all((s_len := s_list.len()) == 1):
         return s.apply(lambda x: x[0] if isinstance(x, Iterable) else x).to_frame()
 
     if s.name is None:
         raise ValueError("the column name should be specified.")
 
-    if suffix and len(suffix) < (max_len := s_len.max()):
+    max_len: int = s_len.max()
+    if suffix and len(suffix) < max_len:
         raise ValueError(
             f"suffix length is less than the max size of {s.name!r} elements.",
         )

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -122,11 +122,8 @@ def expand(
             f"suffix length is less than the max size of {s.name!r} elements.",
         )
 
-    columns = suffix or range(max_len)
     return pd.DataFrame(
-        s_list.tolist(),
-        index=s.index,
-        columns=columns[:max_len],
+        s_list.tolist(), s.index, (suffix or range(max_len))[:max_len]
     ).add_prefix(s.name + delimiter)
 
 

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -111,15 +111,13 @@ def expand(
     """
 
     s_list = s.apply(_wrap_collapse, flatten=flatten)
-    s_len = s_list.len()
-    if all(s_len == 1):
+    if all(s_len := s_list.len() == 1):
         return s.apply(lambda x: x[0] if isinstance(x, Iterable) else x).to_frame()
 
     if s.name is None:
         raise ValueError("the column name should be specified.")
 
-    max_len = s_len.max()
-    if suffix and len(suffix) < max_len:
+    if suffix and len(suffix) < (max_len := s_len.max()):
         raise ValueError(
             f"suffix length is less than the max size of {s.name!r} elements.",
         )

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -115,7 +115,7 @@ def expand(
     s_list = s.apply(_wrap_collapse, flatten=flatten)
     s_len = s_list.len()
     if all(s_len == 1):
-        return s
+        return s.apply(lambda x: x[0] if isinstance(x, Iterable) else x).to_frame()
 
     if s.name is None:
         raise ValueError("the column name should be specified.")

--- a/dtoolkit/accessor/series/expand.py
+++ b/dtoolkit/accessor/series/expand.py
@@ -125,8 +125,8 @@ def expand(
 
     return pd.DataFrame(
         s_list.tolist(),
-        s.index,
-        (suffix or range(max_len))[:max_len],
+        index=s.index,
+        columns=(suffix or range(max_len))[:max_len],
     ).add_prefix(s.name + delimiter)
 
 

--- a/test/accessor/series/test_expand.py
+++ b/test/accessor/series/test_expand.py
@@ -141,7 +141,8 @@ def test_error(suffix, data, name, error):
 
 
 def test_not_list_like_type():
-    s = pd.Series([1, 2, 3])
+    s = pd.Series([1, 2, 3], name="item")
     result = s.expand()
+    expected = pd.DataFrame({"item": [1, 2, 3]})
 
-    assert s is result
+    assert assert_frame_equal(result, expected)

--- a/test/accessor/series/test_expand.py
+++ b/test/accessor/series/test_expand.py
@@ -141,8 +141,7 @@ def test_error(suffix, data, name, error):
 
 
 def test_not_list_like_type():
-    s = pd.Series([1, 2, 3], name="item")
-    result = s.expand()
+    result = pd.Series([1, 2, 3], name="item").expand()
     expected = pd.DataFrame({"item": [1, 2, 3]})
 
-    assert assert_frame_equal(result, expected)
+    assert_frame_equal(result, expected)

--- a/test/accessor/series/test_expand.py
+++ b/test/accessor/series/test_expand.py
@@ -96,17 +96,20 @@ from dtoolkit.accessor.series import expand  # noqa: F401
                 "item_2": [np.nan, 5, np.nan],
             },
         ),
+        (
+            None,
+            "_",
+            False,
+            [[1], [2]],
+            "item",
+            {"item": [1, 2]},
+        ),
     ],
 )
 def test_work(suffix, delimiter, flatten, data, name, expected):
     s = pd.Series(data, name=name)
     expected = pd.DataFrame(expected)
-
-    result = s.expand(
-        suffix=suffix,
-        delimiter=delimiter,
-        flatten=flatten,
-    )
+    result = s.expand(suffix=suffix, delimiter=delimiter, flatten=flatten)
 
     assert_frame_equal(result, expected)
 

--- a/test/accessor/series/test_expand.py
+++ b/test/accessor/series/test_expand.py
@@ -7,15 +7,15 @@ from dtoolkit.accessor.series import expand  # noqa: F401
 
 
 @pytest.mark.parametrize(
-    "suffix, delimiter, data, name, flatten, expected",
+    "suffix, delimiter, flatten, data, name, expected",
     [
         # test default parameters
         (
             None,
             "_",
+            False,
             [(1, 2), (3, 4)],
             "item",
-            False,
             {
                 "item_0": [1, 3],
                 "item_1": [2, 4],
@@ -25,9 +25,9 @@ from dtoolkit.accessor.series import expand  # noqa: F401
         (
             None,
             "-",
+            False,
             [(1, 2), (3, 4)],
             "item",
-            False,
             {
                 "item-0": [1, 3],
                 "item-1": [2, 4],
@@ -37,9 +37,9 @@ from dtoolkit.accessor.series import expand  # noqa: F401
         (
             ["a", "b"],
             "_",
+            False,
             [(1, 2), (3, 4)],
             "item",
-            False,
             {
                 "item_a": [1, 3],
                 "item_b": [2, 4],
@@ -49,9 +49,9 @@ from dtoolkit.accessor.series import expand  # noqa: F401
         (
             ["a", "b", "c"],
             "_",
+            False,
             [(1, 2), (3, 4)],
             "item",
-            False,
             {
                 "item_a": [1, 3],
                 "item_b": [2, 4],
@@ -61,9 +61,9 @@ from dtoolkit.accessor.series import expand  # noqa: F401
         (
             None,
             "_",
+            False,
             [(1, 2), (3, 4, 5)],
             "item",
-            False,
             {
                 "item_0": [1, 3],
                 "item_1": [2, 4],
@@ -74,9 +74,9 @@ from dtoolkit.accessor.series import expand  # noqa: F401
         (
             ["a", "b", "c", "d"],
             "_",
+            False,
             [(1, 2), (3, 4, 5)],
             "item",
-            False,
             {
                 "item_a": [1, 3],
                 "item_b": [2, 4],
@@ -87,9 +87,9 @@ from dtoolkit.accessor.series import expand  # noqa: F401
         (
             None,
             "_",
+            True,
             [(1, 2), (3, [4, 5]), [[6]]],
             "item",
-            True,
             {
                 "item_0": [1, 3, 6],
                 "item_1": [2, 4, np.nan],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request!

Please follow these standard acronyms to start the commit message:

- ENH: enhancement
- BUG: bug fix
- DOC: documentation
- TYP: type annotations
- TST: addition or modification of tests
- MAINT: maintenance commit (refactoring, typos, etc.)
- BLD: change related to building
- REL: related to releasing
- API: an (incompatible) API change
- DEP: deprecate something, or remove a deprecated object
- DEV: development tool or utility
- REV: revert an earlier commit
- PERF: performance improvement
- BOT: always commit via a bot
- CI: related to CI or CD
- CLN: Code cleanup
-->

- [x] closes #907
- [x] Previously, expand returned a Series when all elements were single-element iterables. Now it consistently returns a DataFrame, ensuring uniform output type.