### PR TITLE
MAINT: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/versioneer.yaml
+++ b/.github/workflows/versioneer.yaml
@@ -1,5 +1,9 @@
 name: versioneer
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/Zeroto521/my-data-toolkit/security/code-scanning/13](https://github.com/Zeroto521/my-data-toolkit/security/code-scanning/13)

In general, the fix is to add an explicit `permissions` block that grants only the scopes this workflow actually needs. Because this job checks out code, modifies it, and then uses `peter-evans/create-pull-request` to open a PR from a branch, it needs the ability to read repository contents and to write commits/branches and pull requests. The minimal, clear choice is to set `permissions` at the workflow root (so it applies to all jobs) and grant `contents: write` and `pull-requests: write`. If you want to be stricter, you could use a job-level `permissions` block instead, but there is only one job here, so a root-level block is straightforward and preserves existing behavior while documenting required privileges.

Concretely, in `.github/workflows/versioneer.yaml`, insert a `permissions:` section near the top-level, alongside `name:` and `on:`. For example, after the `name: versioneer` line, add:

```yaml
permissions:
  contents: write
  pull-requests: write
```

No additional imports or external definitions are needed, as this is pure GitHub Actions YAML configuration. This change constrains `GITHUB_TOKEN` to just the permissions that are necessary for this automation to update files and open a pull request, addressing the CodeQL alert.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
