### PR TITLE
MAINT: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Zeroto521/my-data-toolkit/security/code-scanning/3](https://github.com/Zeroto521/my-data-toolkit/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/test.yaml` at the workflow root (recommended here since it applies uniformly to the single job).  
Use least privilege baseline:

```yaml
permissions:
  contents: read
```

This is the minimal starting point recommended by the alert and is sufficient for typical checkout/test workflows. No imports, methods, or other definitions are needed (YAML workflow config only). Insert it after the `on:` triggers block (before `concurrency:`), so it clearly applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
