### PR TITLE
MAINT: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   sdist:
     runs-on: ubuntu-latest
@@ -75,6 +78,8 @@ jobs:
   publish-to-GitHub:
     needs: sdist
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
Potential fix for [https://github.com/Zeroto521/my-data-toolkit/security/code-scanning/6](https://github.com/Zeroto521/my-data-toolkit/security/code-scanning/6)

Add explicit `permissions` to the workflow and override where write access is actually required.

Best fix here (without changing functionality):
1. Add a **workflow-level** `permissions` block after `on:` with least-privilege defaults:
   - `contents: read`
2. Add a **job-level** override for `publish-to-GitHub` because `softprops/action-gh-release` needs to create/update a release:
   - `contents: write`

This keeps all other jobs read-only and grants write only to the one job that needs it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
